### PR TITLE
CI: travis and dummy test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+dist: trusty
+sudo: required
+osx_image: xcode8
+language: java
+
+os:
+  - linux
+
+env:
+  - V=3.3.0
+
+before_install:
+  - OS=linux
+  - ARCH=x86_64
+  - GH_BASE="https://github.com/bazelbuild/bazel/releases/download/$V"
+  - GH_ARTIFACT="bazel-$V-installer-$OS-$ARCH.sh"
+  - CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=$OS-$ARCH/lastSuccessfulBuild/artifact/output/ci"
+  - CI_ARTIFACT="bazel--installer.sh"
+  - URL="$GH_BASE/$GH_ARTIFACT"
+  - if [[ "$V" == "HEAD" ]]; then CI_ARTIFACT="`wget -qO- $CI_BASE | grep -o 'bazel-[-_a-zA-Z0-9\.]*-installer.sh' | uniq`"; fi
+  - if [[ "$V" == "HEAD" ]]; then URL="$CI_BASE/$CI_ARTIFACT"; fi
+  - echo $URL
+  - wget -O install.sh $URL
+  - chmod +x install.sh
+  - ./install.sh --user
+  - rm -f install.sh
+script:
+  - bazel test //protocol/...

--- a/protocol/pubsub/v1/BUILD
+++ b/protocol/pubsub/v1/BUILD
@@ -1,0 +1,4 @@
+cc_test(
+    name="dummy_test",
+    srcs=["dummy_test.cc"],
+)

--- a/protocol/pubsub/v1/dummy_test.cc
+++ b/protocol/pubsub/v1/dummy_test.cc
@@ -1,4 +1,3 @@
 int main() {
-  // This binary always succeeds.
   return 0;
 }

--- a/protocol/pubsub/v1/dummy_test.cc
+++ b/protocol/pubsub/v1/dummy_test.cc
@@ -1,0 +1,4 @@
+int main() {
+  // This binary always succeeds.
+  return 0;
+}


### PR DESCRIPTION
Issue #5 
Sets up Travis CI and includes a simple dummy test to ensure that the Travis CI configuration is correct.

!!! NOTE !!! : I activated Travis CI on my fork of the repo to be tracked on my Travis CI account, but I think that an owner of the main repo will need to set up a Travis CI account and enable the CI. 
______
Rough Steps:
1. Make an account at the [Travis CI website](https://github.com/googleinterns/cloudevents-sdk-cpp/pull/travis-ci.org/) with the same Github account that owns the CE-SDK-CPP repository, 
2. Navigate to the repository list on the Travis CI webiste, and 
3. Activate CI on the CE-SDK-CPP repository.
