### PR TITLE
[Stage 2] Formatting: Json Formatter

### DIFF
--- a/third_party/base64/BUILD
+++ b/third_party/base64/BUILD
@@ -7,9 +7,6 @@ cc_library(
         "base64.h",
         "os.h",
     ],
-    deps = [
-        "//third_party/statusor:statusor_lib",
-    ],
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/base64/base64.cc
+++ b/third_party/base64/base64.cc
@@ -247,4 +247,4 @@ std::string base64_decode(std::string_view s, bool remove_linebreaks) {
 
 #endif  // __cplusplus >= 201703L
 
-} // base64
+}  // namespace base64

--- a/third_party/base64/base64.h
+++ b/third_party/base64/base64.h
@@ -34,7 +34,7 @@ std::string base64_encode_mime(std::string_view s);
 std::string base64_decode(std::string_view s, bool remove_linebreaks = false);
 #endif  // __cplusplus >= 201703L
 
-} // base64
+}  // namespace base64
 
-#endif /* BASE64_H_C0CE2A47_D10E_42C9_A27C_C883944E704A */
+#endif  /* BASE64_H_C0CE2A47_D10E_42C9_A27C_C883944E704A */
 

--- a/third_party/base64/base64_test.cc
+++ b/third_party/base64/base64_test.cc
@@ -77,4 +77,4 @@ TEST(Decode, FillTwo) {
 }
 
 
-} // base64
+}  // namespace base64

--- a/v1/event_format/BUILD
+++ b/v1/event_format/BUILD
@@ -1,4 +1,27 @@
+cc_library(
+    name = "json_formatter_lib",
+    srcs = ["json_formatter.cc"],
+    hdrs = [
+        "json_formatter.h",
+        "formatter.h",
+        "structured_cloud_event.h",
+        "format.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:cloud_event_cc_proto",
+        "//third_party/statusor:statusor_lib",
+        "@com_github_open_source_parsers_jsoncpp//:jsoncpp",
+        "//v1/util:cloud_events_util_lib",
+    ],
+)
+
 cc_test(
-    name="dummy_test",
-    srcs=["dummy_test.cc"],
+   name = "json_formatter_test",
+   srcs = ["json_formatter_test.cc"],
+   deps = [
+       ":json_formatter_lib",
+       "@gtest//:gtest",
+       "@gtest//:gtest_main"
+   ],
 )

--- a/v1/event_format/dummy_test.cc
+++ b/v1/event_format/dummy_test.cc
@@ -1,3 +1,0 @@
-int main() {
-  return 0;
-}

--- a/v1/event_format/format.h
+++ b/v1/event_format/format.h
@@ -10,7 +10,7 @@ namespace format {
  */
 enum class Format {kJson};
 
-} // format
-} // cloudevents
+}  // namespace format
+}  // namespace cloudevents
 
-#endif //CLOUDEVENTCPPSDK_V1_EVENTFORMAT_FORMAT_H_
+#endif  // CLOUDEVENTCPPSDK_V1_EVENTFORMAT_FORMAT_H_

--- a/v1/event_format/formatter.h
+++ b/v1/event_format/formatter.h
@@ -14,17 +14,17 @@ namespace format {
  * StructuredCloudEvents (serializations based on EventFormats)
  */
 class Formatter {
-    public:
-        // Marshal a CloudEvent into a StructuredCloudEvent
-        virtual absl::StatusOr<StructuredCloudEvent> Serialize(
-            const io::cloudevents::v1::CloudEvent& cloud_event) = 0;
-        
-        // Marshal a StructuredCloudEvent into a CloudEvent
-        virtual absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
-            const StructuredCloudEvent& structured_cloud_event) = 0;
+ public:
+  // Marshal a CloudEvent into a StructuredCloudEvent
+  virtual absl::StatusOr<StructuredCloudEvent> Serialize(
+    const io::cloudevents::v1::CloudEvent& cloud_event) = 0;
+  
+  // Marshal a StructuredCloudEvent into a CloudEvent
+  virtual absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
+    const StructuredCloudEvent& structured_cloud_event) = 0;
 };
 
-} // format
-} // cloudevents
+}  // namespace format
+}  // namespace cloudevents
 
 #endif //CLOUDEVENTCPPSDK_V1_EVENTFORMAT_FORMATTER_H_

--- a/v1/event_format/formatter.h
+++ b/v1/event_format/formatter.h
@@ -16,15 +16,19 @@ namespace format {
 class Formatter {
  public:
   // Marshal a CloudEvent into a StructuredCloudEvent
-  virtual absl::StatusOr<StructuredCloudEvent> Serialize(
+  virtual absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> Serialize(
     const io::cloudevents::v1::CloudEvent& cloud_event) = 0;
-  
+
   // Marshal a StructuredCloudEvent into a CloudEvent
   virtual absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
     const StructuredCloudEvent& structured_cloud_event) = 0;
+
+  // Pure virtual destructor as any class with virtual functions
+  // should have a virtual destructor
+  virtual ~Formatter(){};
 };
 
 }  // namespace format
 }  // namespace cloudevents
 
-#endif //CLOUDEVENTCPPSDK_V1_EVENTFORMAT_FORMATTER_H_
+#endif  // CLOUDEVENTCPPSDK_V1_EVENTFORMAT_FORMATTER_H_

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -123,5 +123,29 @@ absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
   return cloud_event;
 }
 
+absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(
+    const CloudEvent_CloudEventAttribute& attr){
+  switch (attr.attr_oneof_case()) {
+    case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:
+      return Json::Value(attr.ce_boolean());
+    case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeInteger:
+      return Json::Value(attr.ce_integer());
+    case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeString:
+      return Json::Value(attr.ce_string());
+    case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBinary:
+      return Json::Value(attr.ce_binary());
+    case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeUri:
+      return Json::Value(attr.ce_uri());
+    case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeUriReference:
+      return Json::Value(attr.ce_uri_reference());
+    case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeTimestamp:
+      return Json::Value(TimeUtil::ToString(attr.ce_timestamp()));
+    case CloudEvent_CloudEventAttribute::AttrOneofCase::ATTR_ONEOF_NOT_SET:
+      return absl::InvalidArgumentError(
+        "Cloud Event metadata attribute not set.");
+  }
+  return absl::InternalError("A Cloud Event attribute was not handled.");
+}
+
 }  // namespace format
 }  // namespace cloudevents

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -27,5 +27,50 @@ constexpr char kErrProtobufAny[] = "protobuf::Any not supported yet.";
 constexpr char kErrNotJson[] = "The given serialized data should not be handled by JsonFormatter because it is not JSON-formatted.";
 constexpr char kErrTwoPayloads[] = "The given serialized data is invalid because it contains two data payloads.";
 
+absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> JsonFormatter::Serialize(
+    const CloudEvent& cloud_event) {
+  absl::Status is_valid = CloudEventsUtil::IsValid(cloud_event);
+  if (!is_valid.ok()) {
+    return is_valid;
+  }
+
+  absl::StatusOr<CeAttrMap> attrs = CloudEventsUtil::GetMetadata(
+    cloud_event);
+  if (!attrs.ok()) {
+    return attrs.status();
+  }
+
+  Json::Value root;
+  for (auto const& attr : (*attrs)) {
+    absl::StatusOr<Json::Value> json_printed = PrintToJson(attr.second);
+    if (!json_printed.ok()) {
+      return json_printed.status();
+    }
+    root[attr.first] = (*json_printed);
+  }
+
+  switch (cloud_event.data_oneof_case()) {
+    case CloudEvent::DataOneofCase::kBinaryData:
+      root[kJsonBinaryKey] = cloud_event.binary_data();
+      break;
+    case CloudEvent::DataOneofCase::kTextData:
+      root[kJsonTextKey] = cloud_event.text_data();
+      break;
+    case CloudEvent::DataOneofCase::kProtoData:
+      // TODO (#17): Handle CloudEvent Any in JsonFormatter
+      return absl::UnimplementedError(kErrProtobufAny);
+    case CloudEvent::DATA_ONEOF_NOT_SET:
+      break;
+  }
+
+  // Write JSON serialized data as std::string
+  Json::StreamWriterBuilder builder;
+  auto structured_ce = absl::make_unique<StructuredCloudEvent>();
+  (*structured_ce).format = Format::kJson;
+  (*structured_ce).serialized_data = Json::writeString(builder, root);
+
+  return structured_ce;
+}
+
 }  // namespace format
 }  // namespace cloudevents

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -72,5 +72,56 @@ absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> JsonFormatter::Serialize(
   return structured_ce;
 }
 
+absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
+    const StructuredCloudEvent& structured_ce) {
+  // Validate that this is the right format to be handled by this object
+  if (structured_ce.format != Format::kJson) {
+    return absl::InternalError(kErrNotJson);
+  }
+
+  // Create a Json::Value from the serialized data string
+  std::string serialized_data = structured_ce.serialized_data;
+  Json::CharReaderBuilder builder;
+  Json::CharReader* reader = builder.newCharReader();
+  std::string errors;
+  Json::Value root;
+
+  bool parsingSuccessful = reader->parse(
+    serialized_data.c_str(),
+    serialized_data.c_str() + serialized_data.size(),
+    &root,
+    &errors);
+  if (!parsingSuccessful) {
+    return absl::InvalidArgumentError(errors);
+  }
+
+  CloudEvent cloud_event;
+
+  // TODO (#39): Should we try to infer CE Type from serialized_data?
+  for (auto const& member : root.getMemberNames()) {
+    absl::Status set_metadata = CloudEventsUtil::SetMetadata(member,
+      root[member].asString(),
+      cloud_event);
+    if (!set_metadata.ok()){
+      return set_metadata;
+    }
+  }
+
+  if (root.isMember(kJsonTextKey) && root.isMember(kJsonBinaryKey)) {
+    return absl::InvalidArgumentError(kErrTwoPayloads);
+  } else if (root.isMember(kJsonTextKey)) {
+    cloud_event.set_text_data(root[kJsonTextKey].asString());
+  } else if (root.isMember(kJsonBinaryKey)) {
+    cloud_event.set_binary_data(root[kJsonBinaryKey].asString());
+  }
+
+  absl::Status is_valid = CloudEventsUtil::IsValid(cloud_event);
+  if (!is_valid.ok()) {
+    return is_valid;
+  }
+
+  return cloud_event;
+}
+
 }  // namespace format
 }  // namespace cloudevents

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -1,0 +1,31 @@
+#include "json_formatter.h"
+
+#include <google/protobuf/any.pb.h>
+#include <google/protobuf/message.h>
+#include <google/protobuf/util/json_util.h>
+#include <google/protobuf/util/time_util.h>
+
+#include "v1/util/cloud_events_util.h"
+
+namespace cloudevents {
+namespace format {
+
+using ::io::cloudevents::v1::CloudEvent;
+using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
+using ::google::protobuf::util::TimeUtil;
+using ::cloudevents::cloudevents_util::CloudEventsUtil;
+
+typedef absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute>
+  CeAttrMap;
+
+// Attribute keys
+constexpr char kJsonBinaryKey[] = "data_base64";
+constexpr char kJsonTextKey[] = "data";
+
+// Error statuses
+constexpr char kErrProtobufAny[] = "protobuf::Any not supported yet.";
+constexpr char kErrNotJson[] = "The given serialized data should not be handled by JsonFormatter because it is not JSON-formatted.";
+constexpr char kErrTwoPayloads[] = "The given serialized data is invalid because it contains two data payloads.";
+
+}  // namespace format
+}  // namespace cloudevents

--- a/v1/event_format/json_formatter.h
+++ b/v1/event_format/json_formatter.h
@@ -25,11 +25,11 @@ class JsonFormatter: public Formatter {
     const StructuredCloudEvent& structured_ce) override;
 
  private:
-//   // Convert from CE to JSON Type System according to
-//   // Relies on the overloaded constructor for Json::Value in jsoncpp
-//   // https://github.com/cloudevents/spec/blob/master/json-format.md#22-type-system-mapping
-//   absl::StatusOr<Json::Value> PrintToJson(
-//     const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
+  // Convert from CE to JSON Type System according to
+  // Relies on the overloaded constructor for Json::Value in jsoncpp
+  // https://github.com/cloudevents/spec/blob/master/json-format.md#22-type-system-mapping
+  absl::StatusOr<Json::Value> PrintToJson(
+    const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
 };
 
 }  // namespace format

--- a/v1/event_format/json_formatter.h
+++ b/v1/event_format/json_formatter.h
@@ -1,0 +1,38 @@
+#ifndef CLOUDEVENTCPPSDK_V1_EVENTFORMAT_JSONFORMATTER_H_
+#define CLOUDEVENTCPPSDK_V1_EVENTFORMAT_JSONFORMATTER_H_
+
+#include <json/json.h>
+
+#include "proto/cloud_event.pb.h"
+#include "third_party/statusor/statusor.h"
+#include "v1/event_format/formatter.h"
+#include "v1/event_format/structured_cloud_event.h"
+
+namespace cloudevents {
+namespace format {
+
+/*
+ * Implementation of Formatter for JSON EventFormat
+ */
+class JsonFormatter: public Formatter {
+ public:
+//   // Create Json-formatted serialization from CloudEvent
+//   absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> Serialize(
+//   const io::cloudevents::v1::CloudEvent& cloud_event) override;
+
+//   // Create CloudEvent from Json-formatted serialization
+//   absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
+//   const StructuredCloudEvent& structured_ce) override;
+
+ private:
+//   // Convert from CE to JSON Type System according to
+//   // Relies on the overloaded constructor for Json::Value in jsoncpp
+//   // https://github.com/cloudevents/spec/blob/master/json-format.md#22-type-system-mapping
+//   absl::StatusOr<Json::Value> PrintToJson(
+//   const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
+};
+
+}  // namespace format
+}  // namespace cloudevents
+
+#endif  // CLOUDEVENTCPPSDK_V1_EVENTFORMAT_JSONFORMATTER_H_

--- a/v1/event_format/json_formatter.h
+++ b/v1/event_format/json_formatter.h
@@ -16,20 +16,20 @@ namespace format {
  */
 class JsonFormatter: public Formatter {
  public:
-//   // Create Json-formatted serialization from CloudEvent
-//   absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> Serialize(
-//   const io::cloudevents::v1::CloudEvent& cloud_event) override;
+  // Create Json-formatted serialization from CloudEvent
+  absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> Serialize(
+    const io::cloudevents::v1::CloudEvent& cloud_event) override;
 
 //   // Create CloudEvent from Json-formatted serialization
 //   absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
-//   const StructuredCloudEvent& structured_ce) override;
+//     const StructuredCloudEvent& structured_ce) override;
 
  private:
 //   // Convert from CE to JSON Type System according to
 //   // Relies on the overloaded constructor for Json::Value in jsoncpp
 //   // https://github.com/cloudevents/spec/blob/master/json-format.md#22-type-system-mapping
 //   absl::StatusOr<Json::Value> PrintToJson(
-//   const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
+//     const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
 };
 
 }  // namespace format

--- a/v1/event_format/json_formatter.h
+++ b/v1/event_format/json_formatter.h
@@ -20,9 +20,9 @@ class JsonFormatter: public Formatter {
   absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> Serialize(
     const io::cloudevents::v1::CloudEvent& cloud_event) override;
 
-//   // Create CloudEvent from Json-formatted serialization
-//   absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
-//     const StructuredCloudEvent& structured_ce) override;
+  // Create CloudEvent from Json-formatted serialization
+  absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
+    const StructuredCloudEvent& structured_ce) override;
 
  private:
 //   // Convert from CE to JSON Type System according to

--- a/v1/event_format/json_formatter_test.cc
+++ b/v1/event_format/json_formatter_test.cc
@@ -1,0 +1,114 @@
+#include "json_formatter.h"
+#include <gtest/gtest.h>
+
+namespace cloudevents {
+namespace format {
+using ::io::cloudevents::v1::CloudEvent;
+using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
+
+TEST(Serialize, NoData) {
+  CloudEvent cloud_event;
+  cloud_event.set_id("1");
+  cloud_event.set_source("/test");
+  cloud_event.set_spec_version("1.0");
+  cloud_event.set_type("test");
+  std::string expected_ser = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
+  JsonFormatter json_formatter;
+  absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
+
+  serialize = json_formatter.Serialize(cloud_event);
+
+  ASSERT_TRUE(serialize.ok());
+  // dereference twice to unwrap StatusOr and unique_ptr
+  ASSERT_EQ((*(*serialize)).format, Format::kJson);
+  ASSERT_EQ((*(*serialize)).serialized_data, expected_ser);
+}
+
+TEST(Serialize, BinaryData) {
+  CloudEvent cloud_event;
+  cloud_event.set_id("4545");
+  cloud_event.set_source("/bonk+bonk");
+  cloud_event.set_spec_version("3.xxxxx");
+  cloud_event.set_type("new");
+  cloud_event.set_binary_data("0110");
+  std::string expected_ser = "{\n\t\"data_base64\" : \"0110\",\n\t\"id\" : \"4545\",\n\t\"source\" : \"/bonk+bonk\",\n\t\"spec_version\" : \"3.xxxxx\",\n\t\"type\" : \"new\"\n}";
+  JsonFormatter json_formatter;
+  absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
+
+  serialize = json_formatter.Serialize(cloud_event);
+
+  ASSERT_TRUE(serialize.ok());
+  ASSERT_EQ((*(*serialize)).format, Format::kJson);
+  ASSERT_EQ((*(*serialize)).serialized_data, expected_ser);
+}
+
+TEST(Serialize, TextData) {
+  CloudEvent cloud_event;
+  cloud_event.set_id("9999999");
+  cloud_event.set_source("/test/qwertyuiop");
+  cloud_event.set_spec_version("4.xxxxx");
+  cloud_event.set_type("not_a_type");
+  cloud_event.set_text_data("this is text");
+  std::string expected_ser = "{\n\t\"data\" : \"this is text\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"4.xxxxx\",\n\t\"type\" : \"not_a_type\"\n}";
+  JsonFormatter json_formatter;
+  absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
+
+  serialize = json_formatter.Serialize(cloud_event);
+
+  ASSERT_TRUE(serialize.ok());
+  ASSERT_EQ((*(*serialize)).format, Format::kJson);
+  ASSERT_EQ((*(*serialize)).serialized_data, expected_ser);
+}
+
+TEST(Deserialize, NoData) {
+  StructuredCloudEvent structured_ce;
+  structured_ce.format = Format::kJson;
+  structured_ce.serialized_data = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
+  JsonFormatter json_formatter;
+  absl::StatusOr<CloudEvent> deserialize;
+
+  deserialize = json_formatter.Deserialize(structured_ce);
+
+  ASSERT_TRUE(deserialize.ok());
+  ASSERT_EQ((*deserialize).id(), "1");
+  ASSERT_EQ((*deserialize).source(), "/test");
+  ASSERT_EQ((*deserialize).spec_version(), "1.0");
+  ASSERT_EQ((*deserialize).type(), "test");
+}
+
+TEST(Deserialize, BinaryData) {
+  StructuredCloudEvent structured_ce;
+  structured_ce.format = Format::kJson;
+  structured_ce.serialized_data = "{\n\t\"data_base64\" : \"binary_data_wow\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"3.xxxxx\",\n\t\"type\" : \"not_a_type\"\n}";
+  JsonFormatter json_formatter;
+  absl::StatusOr<CloudEvent> deserialize;
+
+  deserialize = json_formatter.Deserialize(structured_ce);
+
+  ASSERT_TRUE(deserialize);
+  ASSERT_EQ((*deserialize).id(), "9999999");
+  ASSERT_EQ((*deserialize).source(), "/test/qwertyuiop");
+  ASSERT_EQ((*deserialize).spec_version(), "3.xxxxx");
+  ASSERT_EQ((*deserialize).type(), "not_a_type");
+  ASSERT_EQ((*deserialize).binary_data(), "binary_data_wow");
+}
+
+TEST(Deserialize, TextData) {
+  StructuredCloudEvent structured_ce;
+  structured_ce.format = Format::kJson;
+  structured_ce.serialized_data = "{\n\t\"data\" : \"this is text\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"4\",\n\t\"type\" : \"not_a_type\"\n}";
+  JsonFormatter json_formatter;
+  absl::StatusOr<CloudEvent> deserialize;
+
+  deserialize = json_formatter.Deserialize(structured_ce);
+
+  ASSERT_TRUE(deserialize);
+  ASSERT_EQ((*deserialize).id(), "9999999");
+  ASSERT_EQ((*deserialize).source(), "/test/qwertyuiop");
+  ASSERT_EQ((*deserialize).spec_version(), "4");
+  ASSERT_EQ((*deserialize).type(), "not_a_type");
+  ASSERT_EQ((*deserialize).text_data(), "this is text");
+}
+
+}  // namespace format
+}  // namespace cloudevents

--- a/v1/event_format/json_formatter_test.cc
+++ b/v1/event_format/json_formatter_test.cc
@@ -20,8 +20,8 @@ TEST(Serialize, NoData) {
 
   ASSERT_TRUE(serialize.ok());
   // dereference twice to unwrap StatusOr and unique_ptr
-  ASSERT_EQ((*(*serialize)).format, Format::kJson);
-  ASSERT_EQ((*(*serialize)).serialized_data, expected_ser);
+  ASSERT_EQ((**serialize).format, Format::kJson);
+  ASSERT_EQ((**serialize).serialized_data, expected_ser);
 }
 
 TEST(Serialize, BinaryData) {
@@ -38,8 +38,8 @@ TEST(Serialize, BinaryData) {
   serialize = json_formatter.Serialize(cloud_event);
 
   ASSERT_TRUE(serialize.ok());
-  ASSERT_EQ((*(*serialize)).format, Format::kJson);
-  ASSERT_EQ((*(*serialize)).serialized_data, expected_ser);
+  ASSERT_EQ((**serialize).format, Format::kJson);
+  ASSERT_EQ((**serialize).serialized_data, expected_ser);
 }
 
 TEST(Serialize, TextData) {
@@ -56,8 +56,8 @@ TEST(Serialize, TextData) {
   serialize = json_formatter.Serialize(cloud_event);
 
   ASSERT_TRUE(serialize.ok());
-  ASSERT_EQ((*(*serialize)).format, Format::kJson);
-  ASSERT_EQ((*(*serialize)).serialized_data, expected_ser);
+  ASSERT_EQ((**serialize).format, Format::kJson);
+  ASSERT_EQ((**serialize).serialized_data, expected_ser);
 }
 
 TEST(Deserialize, NoData) {

--- a/v1/event_format/structured_cloud_event.h
+++ b/v1/event_format/structured_cloud_event.h
@@ -11,14 +11,14 @@ namespace format {
  * according to an EventFormat spec.
  */
 struct StructuredCloudEvent {
-    // The EventFormat spec used to create this serialization
-    Format format;
+  // The EventFormat spec used to create this serialization
+  Format format;
 
-    // The serialization of the CloudEvent
-    std::string serialization;
+  // The serialization of the CloudEvent
+  std::string serialization;
 };
 
-} // format
-} // cloudevents
+}  // namespace format
+}  // namespace cloudevents
 
-#endif //CLOUDEVENTCPPSDK_V1_EVENTFORMAT_STRUCTUREDCLOUDEVENT_H_
+#endif  // CLOUDEVENTCPPSDK_V1_EVENTFORMAT_STRUCTUREDCLOUDEVENT_H_

--- a/v1/event_format/structured_cloud_event.h
+++ b/v1/event_format/structured_cloud_event.h
@@ -15,7 +15,7 @@ struct StructuredCloudEvent {
   Format format;
 
   // The serialization of the CloudEvent
-  std::string serialization;
+  std::string serialized_data;
 };
 
 }  // namespace format

--- a/v1/util/BUILD
+++ b/v1/util/BUILD
@@ -1,0 +1,26 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "cloud_events_util_lib",
+    srcs = ["cloud_events_util.cc"],
+    hdrs = [
+        "cloud_events_util.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
+        "//third_party/statusor:statusor_lib",
+        "//third_party/base64:base64_lib",
+        "//proto:cloud_event_cc_proto",
+    ],
+)
+
+cc_test(
+   name = "cloud_events_util_test",
+   srcs = ["cloud_events_util_test.cc"],
+   deps = [
+       ":cloud_events_util_lib",
+       "@gtest//:gtest",
+       "@gtest//:gtest_main"
+   ],
+)

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -43,5 +43,23 @@ absl::StatusOr<
     return attrs;
 }
 
+void CloudEventsUtil::SetMetadata(const std::string& key,
+        const std::string& val, CloudEvent& cloud_event){
+    // TODO (#39): Should we try to infer CE Type from serialization?
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_string(val);
+    if (key == "id") {
+        cloud_event.set_id(val);
+    } else if (key == "source") {
+        cloud_event.set_source(val);
+    } else if (key == "spec_version") {
+        cloud_event.set_spec_version(val);
+    } else if (key == "type") {
+        cloud_event.set_type(val);
+    } else {
+        (*cloud_event.mutable_attributes())[key] = attr;
+    }
+}
+
 }  // namespace cloudevents_util
 }  // namespace cloudevents

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -1,0 +1,13 @@
+#include "cloud_events_util.h"
+
+#include <google/protobuf/util/time_util.h>
+
+namespace cloudevents {
+namespace cloudevents_util {
+
+using ::io::cloudevents::v1::CloudEvent;
+using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
+using ::google::protobuf::util::TimeUtil;
+
+}  // namespace cloudevents_util
+}  // namespace cloudevents

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -16,5 +16,32 @@ bool CloudEventsUtil::IsValid(const CloudEvent& cloud_event) {
         cloud_event.type().empty());
 }
 
+absl::StatusOr<
+        absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute>>
+        CloudEventsUtil::GetMetadata(const CloudEvent& cloud_event) {
+    if (!CloudEventsUtil::IsValid(cloud_event)) {
+        return absl::InvalidArgumentError(
+            "GetMetadata can only be called with valid Cloud Event.");
+    }
+
+    // create absl::flat_hash_map from protobuf map of optional/ extensionattrs
+    absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute> attrs(
+        (cloud_event.attributes()).begin(),
+        cloud_event.attributes().end());
+
+    // insert required attrs
+    CloudEvent_CloudEventAttribute attr_val;
+    attr_val.set_ce_string(cloud_event.id());
+    attrs["id"] = attr_val;
+    attr_val.set_ce_string(cloud_event.source());
+    attrs["source"] = attr_val;
+    attr_val.set_ce_string(cloud_event.spec_version());
+    attrs["spec_version"] = attr_val;
+    attr_val.set_ce_string(cloud_event.type());
+    attrs["type"] = attr_val;
+
+    return attrs;
+}
+
 }  // namespace cloudevents_util
 }  // namespace cloudevents

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -9,5 +9,12 @@ using ::io::cloudevents::v1::CloudEvent;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 using ::google::protobuf::util::TimeUtil;
 
+bool CloudEventsUtil::IsValid(const CloudEvent& cloud_event) {
+    return !(cloud_event.id().empty() ||
+        cloud_event.source().empty() ||
+        cloud_event.spec_version().empty() ||
+        cloud_event.type().empty());
+}
+
 }  // namespace cloudevents_util
 }  // namespace cloudevents

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -10,6 +10,11 @@ using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 using ::google::protobuf::Timestamp;
 using ::google::protobuf::util::TimeUtil;
 
+constexpr char kErrCeInvalid[] = "Given Cloud Event is missing required attributes.";
+constexpr char kErrTimeInvalid[] = "Given time is invalid because it does not comply to RFC 3339.";
+constexpr char kErrAttrNotSet[] = "Given Cloud Event attribute is not set.";
+constexpr char kErrAttrNotHandled[] = "A Cloud Event type is not handled.";
+
 absl::Status CloudEventsUtil::IsValid(const CloudEvent& cloud_event) {
   if (cloud_event.id().empty() ||
       cloud_event.source().empty() ||

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -12,7 +12,7 @@ namespace cloudevents_util {
 class CloudEventsUtil {
     public:
         // validate if given CloudEvent fulfills requirements to be valid
-        static bool IsValid(const io::cloudevents::v1::CloudEvent& cloud_event);
+        static absl::Status IsValid(const io::cloudevents::v1::CloudEvent& cloud_event);
 
         // get metadata from CloudEvent in a single map
         static absl::StatusOr<absl::flat_hash_map<
@@ -22,13 +22,14 @@ class CloudEventsUtil {
         // TODO (#44): Overload SetMetadata to accept a map of attributes
 
         // set metadata without dealing with CloudEvent proto structure
-        static void SetMetadata(const std::string& key, const std::string& val,
+        static absl::Status SetMetadata(const std::string& key, const std::string& val,
             io::cloudevents::v1::CloudEvent& cloud_event);
 
         // convert CloudEvent attributes to canonical string representaiton
         // https://github.com/cloudevents/spec/blob/master/spec.md#type-system
         static absl::StatusOr<std::string> StringifyCeType(
             const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
+
 };
 
 }  // namespace cloudevents_util

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -11,8 +11,8 @@ namespace cloudevents_util {
 
 class CloudEventsUtil {
     public:
-        // // validate if given CloudEvent fulfills requirements to be valid
-        // static bool IsValid(const io::cloudevents::v1::CloudEvent& cloud_event);
+        // validate if given CloudEvent fulfills requirements to be valid
+        static bool IsValid(const io::cloudevents::v1::CloudEvent& cloud_event);
 
         // // get metadata from CloudEvent in a single map
         // static absl::StatusOr<absl::flat_hash_map<

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -10,26 +10,33 @@ namespace cloudevents {
 namespace cloudevents_util {
 
 class CloudEventsUtil {
-    public:
-        // validate if given CloudEvent fulfills requirements to be valid
-        static absl::Status IsValid(const io::cloudevents::v1::CloudEvent& cloud_event);
+ public:
+  // validate if given CloudEvent fulfills requirements to be valid
+  static absl::Status IsValid(
+    const io::cloudevents::v1::CloudEvent& cloud_event);
 
-        // get metadata from CloudEvent in a single map
-        static absl::StatusOr<absl::flat_hash_map<
-            std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
-            GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
+  // get metadata from CloudEvent in a single map
+  static absl::StatusOr<absl::flat_hash_map<
+    std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
+    GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
 
-        // TODO (#44): Overload SetMetadata to accept a map of attributes
+  // TODO (#44): Overload SetMetadata to accept a map of attributes
 
-        // set metadata without dealing with CloudEvent proto structure
-        static absl::Status SetMetadata(const std::string& key, const std::string& val,
-            io::cloudevents::v1::CloudEvent& cloud_event);
+  // set metadata without dealing with CloudEvent proto structure
+  static absl::Status SetMetadata(const std::string& key,
+    const std::string& val,
+    io::cloudevents::v1::CloudEvent& cloud_event);
 
-        // convert CloudEvent attributes to canonical string representaiton
-        // https://github.com/cloudevents/spec/blob/master/spec.md#type-system
-        static absl::StatusOr<std::string> StringifyCeType(
-            const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
+  // convert CloudEvent attributes to canonical string representaiton
+  // https://github.com/cloudevents/spec/blob/master/spec.md#type-system
+  static absl::StatusOr<std::string> ToString(
+    const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
 
+  // convert std::string to ce-string.
+  // ce-string is the default ce-type for unrecognized metadata
+ private:
+  static io::cloudevents::v1::CloudEvent_CloudEventAttribute ToCeString(
+    const std::string& val);
 };
 
 }  // namespace cloudevents_util

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -19,11 +19,11 @@ class CloudEventsUtil {
             std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
             GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
 
-        // // TODO (#44): Overload SetMetadata to accept a map of attributes
+        // TODO (#44): Overload SetMetadata to accept a map of attributes
 
-        // // set metadata without dealing with CloudEvent proto structure
-        // static void SetMetadata(const std::string& key, const std::string& val,
-        //     io::cloudevents::v1::CloudEvent& cloud_event);
+        // set metadata without dealing with CloudEvent proto structure
+        static void SetMetadata(const std::string& key, const std::string& val,
+            io::cloudevents::v1::CloudEvent& cloud_event);
 
         // // convert CloudEvent attributes to canonical string representaiton
         // // https://github.com/cloudevents/spec/blob/master/spec.md#type-system

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -14,10 +14,10 @@ class CloudEventsUtil {
         // validate if given CloudEvent fulfills requirements to be valid
         static bool IsValid(const io::cloudevents::v1::CloudEvent& cloud_event);
 
-        // // get metadata from CloudEvent in a single map
-        // static absl::StatusOr<absl::flat_hash_map<
-        //     std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
-        //     GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
+        // get metadata from CloudEvent in a single map
+        static absl::StatusOr<absl::flat_hash_map<
+            std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
+            GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
 
         // // TODO (#44): Overload SetMetadata to accept a map of attributes
 

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -1,0 +1,37 @@
+#ifndef CLOUDEVENTSCPPSDK_V1_UTIL_CLOUDEVENTSUTIL
+#define CLOUDEVENTSCPPSDK_V1_UTIL_CLOUDEVENTSUTIL
+
+#include "absl/container/flat_hash_map.h"
+#include "third_party/statusor/statusor.h"
+#include "third_party/base64/base64.h"
+#include "proto/cloud_event.pb.h"
+
+namespace cloudevents {
+namespace cloudevents_util {
+
+class CloudEventsUtil {
+    public:
+        // // validate if given CloudEvent fulfills requirements to be valid
+        // static bool IsValid(const io::cloudevents::v1::CloudEvent& cloud_event);
+
+        // // get metadata from CloudEvent in a single map
+        // static absl::StatusOr<absl::flat_hash_map<
+        //     std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
+        //     GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
+
+        // // TODO (#44): Overload SetMetadata to accept a map of attributes
+
+        // // set metadata without dealing with CloudEvent proto structure
+        // static void SetMetadata(const std::string& key, const std::string& val,
+        //     io::cloudevents::v1::CloudEvent& cloud_event);
+
+        // // convert CloudEvent attributes to canonical string representaiton
+        // // https://github.com/cloudevents/spec/blob/master/spec.md#type-system
+        // static absl::StatusOr<std::string> StringifyCeType(
+        //     const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
+};
+
+}  // namespace cloudevents_util
+}  // namespace cloudevents
+
+#endif  // CLOUDEVENTSCPPSDK_V1_UTIL_CLOUDEVENTSUTIL

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -25,10 +25,10 @@ class CloudEventsUtil {
         static void SetMetadata(const std::string& key, const std::string& val,
             io::cloudevents::v1::CloudEvent& cloud_event);
 
-        // // convert CloudEvent attributes to canonical string representaiton
-        // // https://github.com/cloudevents/spec/blob/master/spec.md#type-system
-        // static absl::StatusOr<std::string> StringifyCeType(
-        //     const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
+        // convert CloudEvent attributes to canonical string representaiton
+        // https://github.com/cloudevents/spec/blob/master/spec.md#type-system
+        static absl::StatusOr<std::string> StringifyCeType(
+            const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
 };
 
 }  // namespace cloudevents_util

--- a/v1/util/cloud_events_util_test.cc
+++ b/v1/util/cloud_events_util_test.cc
@@ -1,0 +1,259 @@
+#include "cloud_events_util.h"
+#include <google/protobuf/timestamp.pb.h>
+#include <google/protobuf/util/time_util.h>
+#include <gtest/gtest.h>
+
+namespace cloudevents {
+namespace cloudevents_util {
+
+using ::io::cloudevents::v1::CloudEvent;
+using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
+using ::google::protobuf::Timestamp;
+using ::google::protobuf::util::TimeUtil;
+
+typedef absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute>
+    CeAttrMap;
+
+TEST(CloudEventsUtilTest, IsValid_NoSource) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+
+    ASSERT_FALSE(CloudEventsUtil::IsValid(cloud_event));
+}
+
+TEST(CloudEventsUtilTest, IsValid_NoSpecVersion) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_type("test");
+
+    ASSERT_FALSE(CloudEventsUtil::IsValid(cloud_event));
+}
+
+TEST(CloudEventsUtilTest, IsValid_NoType) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+
+    ASSERT_FALSE(CloudEventsUtil::IsValid(cloud_event));
+}
+
+TEST(CloudEventsUtilTest, IsValid_HasRequired) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+
+    ASSERT_TRUE(CloudEventsUtil::IsValid(cloud_event));
+}
+
+TEST(CloudEventsUtilTest, GetMetadata_InvalidCloudEvent) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+
+    absl::Status get_metadata_status =
+        CloudEventsUtil::GetMetadata(cloud_event).status();
+
+    ASSERT_TRUE(absl::IsInvalidArgument(get_metadata_status));
+}
+
+TEST(CloudEventsUtilTest, GetMetadata_NoOptional) {
+    // setup input to function
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+
+    absl::StatusOr<CeAttrMap> get_metadata =
+        CloudEventsUtil::GetMetadata(cloud_event);
+
+    ASSERT_TRUE(get_metadata.ok());
+    ASSERT_EQ((*get_metadata)["id"].ce_string(), "1");
+    ASSERT_EQ((*get_metadata)["source"].ce_string(), "/test");
+    ASSERT_EQ((*get_metadata)["spec_version"].ce_string(), "1.0");
+    ASSERT_EQ((*get_metadata)["type"].ce_string(), "test");
+}
+
+
+TEST(CloudEventsUtilTest, GetMetadata_OneOptional) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_string("test_val");
+    (*cloud_event.mutable_attributes())["test_key"] = attr;
+
+    absl::StatusOr<CeAttrMap> get_metadata =
+        CloudEventsUtil::GetMetadata(cloud_event);
+    ASSERT_TRUE(get_metadata.ok());
+    ASSERT_EQ((*get_metadata)["id"].ce_string(), "1");
+    ASSERT_EQ((*get_metadata)["source"].ce_string(), "/test");
+    ASSERT_EQ((*get_metadata)["spec_version"].ce_string(), "1.0");
+    ASSERT_EQ((*get_metadata)["type"].ce_string(), "test");
+    ASSERT_EQ((*get_metadata)["test_key"].ce_string(), "test_val");
+}
+
+TEST(CloudEventsUtilTest, GetMetadata_TwoOptional) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_string("test_val1");
+    (*cloud_event.mutable_attributes())["test_key1"] = attr;
+    attr.set_ce_string("test_val2");
+    (*cloud_event.mutable_attributes())["test_key2"] = attr;
+
+    absl::StatusOr<CeAttrMap> get_metadata =
+        CloudEventsUtil::GetMetadata(cloud_event);
+    ASSERT_TRUE(get_metadata.ok());
+    ASSERT_EQ((*get_metadata)["id"].ce_string(), "1");
+    ASSERT_EQ((*get_metadata)["source"].ce_string(), "/test");
+    ASSERT_EQ((*get_metadata)["spec_version"].ce_string(), "1.0");
+    ASSERT_EQ((*get_metadata)["type"].ce_string(), "test");
+    ASSERT_EQ((*get_metadata)["test_key1"].ce_string(), "test_val1");
+    ASSERT_EQ((*get_metadata)["test_key2"].ce_string(), "test_val2");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_Id) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata("id", "1", cloud_event);
+
+    ASSERT_EQ(cloud_event.id(), "1");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_Source) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata("source", "/a_source", cloud_event);
+
+    ASSERT_EQ(cloud_event.source(), "/a_source");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_SpecVersion) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata("spec_version", "1.xx", cloud_event);
+
+    ASSERT_EQ(cloud_event.spec_version(), "1.xx");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_Type) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata("type", "test", cloud_event);
+
+    ASSERT_EQ(cloud_event.type(), "test");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_Optional) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata("opt", "arbitrary", cloud_event);
+
+    CloudEvent_CloudEventAttribute attr = cloud_event.attributes().at("opt");
+    ASSERT_EQ(attr.ce_string(), "arbitrary");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_BoolFalse) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_boolean(false);
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "false");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_BoolTrue) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_boolean(true);
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "true");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_Integer) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_integer(88);
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "88");
+}
+
+
+TEST(CloudEventsUtilTest, StringifyCeType_String) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_string("test");
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "test");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_URI) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_uri("https://google.com");
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "https://google.com");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_URIRef) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_uri_reference("https://www.google.com/#fragment");
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "https://www.google.com/#fragment");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_Timestamp) {
+    Timestamp timestamp = TimeUtil::GetCurrentTime();
+    std::string timestamp_str = TimeUtil::ToString(timestamp);
+    CloudEvent_CloudEventAttribute attr;
+    attr.mutable_ce_timestamp()-> MergeFrom(timestamp);
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_EQ((*stringify_ce_type), timestamp_str);
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_NotSet) {
+    CloudEvent_CloudEventAttribute attr;
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(absl::IsInvalidArgument(stringify_ce_type.status()));
+}
+
+
+}  // namespace cloudevents_util
+}  // namespace cloudevents


### PR DESCRIPTION
[View and comment on changes unique to this PR - *for developmental feedback only!*](https://github.com/googleinterns/cloudevents-sdk-cpp/pull/38/files/a432e3bc2b6f62c19676828287fc865bf522a4a4..9c53cd0ece9d126a003e4df178ae2cf479911813)
**!! On merging, all files changed will apply to master. So all lower stage PRs should be merged first.**
______

[Relevant Documentation
](https://docs.google.com/document/d/1FbVf5VeoREwFvk0SnVPpkHn_JAuZcrXuoo6AJnhuLVg/edit#heading=h.dc7vwc2d6jrl)

- Implements Formatter interface, specifically the method functions Serialize and Deserialize
- Has private function PrintToJson to convert CE-types to Json-types
- Deletes placeholder dummy-test
- Includes whitespace fixes in v1/event_format/...

- [x] Tests pass
- [x] Documentation comments in header files