### PR TITLE
[Stage 3] Util: CloudEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,26 @@ The CloudEvent class (generated from protobuf) is based on this [open PR to the 
 
 The PubsubMessage class (generated from protobuf) is based on [Google API](https://github.com/googleapis/googleapis/blob/master/google/pubsub/v1/pubsub.proto#L188).
 
-
 **This is not an officially supported Google product.**
+
+# User Guide
+## Setup
+Install Bazel. Instuctions found in [Bazel documentation](https://docs.bazel.build/versions/master/install-ubuntu.html).
+
+## Binding a CloudEvent to a Protocol
+### BinaryContentMode
+_Coming soon_
+
+### StructuredContentMode
+_Coming soon_
+
+## Event-formats
+To specify an event-format you want to use:
+1. Import the header file `//v1/event_format/format`.
+2. Pass in the format parameter as `cloudevents::format::_A_FORMAT`. For a specific sample check the documentation on StructuredContentMode.
 
 # Samples
 Run-able code samples are available in the `/samples` folder.
-
-### Setup
-Install Bazel. Instuctions found in [Bazel documentation](https://docs.bazel.build/versions/master/install-ubuntu.html).
 
 ### Run
 1. Create executable <br/>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -75,11 +75,14 @@ http_archive(
     strip_prefix = "rules_proto_grpc-1.0.2",
 )
 
+# _____ JSONCPP _____
+
 git_repository(
     name = "org_cloudabi_bazel_third_party",
     commit = "91ca2167219c612a89334fa09ddf15fbdc5d0592",
     remote = "https://github.com/NuxiNL/bazel-third-party.git",
     shallow_since = "1547652202 +0100",
 )
+
 load("@org_cloudabi_bazel_third_party//:third_party.bzl", "third_party_repositories")
 third_party_repositories()

--- a/v1/event_format/BUILD
+++ b/v1/event_format/BUILD
@@ -20,8 +20,8 @@ cc_test(
    name = "json_formatter_test",
    srcs = ["json_formatter_test.cc"],
    deps = [
-       ":json_formatter_lib",
        "@gtest//:gtest",
-       "@gtest//:gtest_main"
+       "@gtest//:gtest_main",
+       ":json_formatter_lib",
    ],
 )

--- a/v1/event_format/BUILD
+++ b/v1/event_format/BUILD
@@ -1,4 +1,26 @@
+cc_library(
+    name = "json_formatter_lib",
+    srcs = ["json_formatter.cc"],
+    hdrs = [
+        "json_formatter.h",
+        "formatter.h",
+        "structured_cloud_event.h",
+        "format.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto:cloud_event_cc_proto",
+        "//third_party/statusor:statusor_lib",
+        "@com_github_open_source_parsers_jsoncpp//:jsoncpp",
+    ],
+)
+
 cc_test(
-    name="dummy_test",
-    srcs=["dummy_test.cc"],
+   name = "json_formatter_test",
+   srcs = ["json_formatter_test.cc"],
+   deps = [
+       ":json_formatter_lib",
+       "@gtest//:gtest",
+       "@gtest//:gtest_main"
+   ],
 )

--- a/v1/event_format/BUILD
+++ b/v1/event_format/BUILD
@@ -9,9 +9,10 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_open_source_parsers_jsoncpp//:jsoncpp",
         "//proto:cloud_event_cc_proto",
         "//third_party/statusor:statusor_lib",
-        "@com_github_open_source_parsers_jsoncpp//:jsoncpp",
+        "//v1/util:cloud_events_util_lib",
     ],
 )
 

--- a/v1/event_format/dummy_test.cc
+++ b/v1/event_format/dummy_test.cc
@@ -1,3 +1,0 @@
-int main() {
-  return 0;
-}

--- a/v1/event_format/formatter.h
+++ b/v1/event_format/formatter.h
@@ -16,10 +16,12 @@ namespace format {
 class Formatter {
     public:
         // Marshal a CloudEvent into a StructuredCloudEvent
-        virtual absl::StatusOr<StructuredCloudEvent> Serialize(io::cloudevents::v1::CloudEvent cloud_event) = 0;
+        virtual absl::StatusOr<StructuredCloudEvent> Serialize(
+            const io::cloudevents::v1::CloudEvent& cloud_event) = 0;
         
         // Marshal a StructuredCloudEvent into a CloudEvent
-        virtual absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(StructuredCloudEvent structured_cloud_event) = 0;
+        virtual absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
+            const StructuredCloudEvent& structured_cloud_event) = 0;
 };
 
 } // format

--- a/v1/event_format/formatter.h
+++ b/v1/event_format/formatter.h
@@ -1,0 +1,28 @@
+#ifndef CLOUDEVENTCPPSDK_V1_EVENTFORMAT_FORMATTER_H_
+#define CLOUDEVENTCPPSDK_V1_EVENTFORMAT_FORMATTER_H_
+
+#include "proto/cloud_event.pb.h"
+#include "v1/event_format/structured_cloud_event.h"
+#include "third_party/statusor/statusor.h"
+
+namespace cloudevents {
+namespace format {
+
+/*
+ * Abstract Class that will have a concrete implementation for each supported EventFormat.
+ * Formatters will handle marshalling between CloudEvents and 
+ * StructuredCloudEvents (serializations based on EventFormats)
+ */
+class Formatter {
+    public:
+        // Marshal a CloudEvent into a StructuredCloudEvent
+        virtual absl::StatusOr<StructuredCloudEvent> Serialize(io::cloudevents::v1::CloudEvent cloud_event) = 0;
+        
+        // Marshal a StructuredCloudEvent into a CloudEvent
+        virtual absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(StructuredCloudEvent structured_cloud_event) = 0;
+};
+
+} // format
+} // cloudevents
+
+#endif //CLOUDEVENTCPPSDK_V1_EVENTFORMAT_FORMATTER_H_

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -21,7 +21,8 @@ static constexpr absl::string_view kCeTypeKey = "type";
 static constexpr absl::string_view kBinaryDataKey = "data_base64";
 static constexpr absl::string_view kJsonDataKey = "data";
 
-absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(CloudEvent_CloudEventAttribute attr){    
+absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(
+        const CloudEvent_CloudEventAttribute& attr){    
     switch (attr.attr_oneof_case()) {
         case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:
             return Json::Value(attr.ce_boolean());
@@ -43,7 +44,8 @@ absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(CloudEvent_CloudEventAttr
     return absl::InternalError("A Cloud Event attribute has not been handled.");
 }
 
-absl::StatusOr<StructuredCloudEvent> JsonFormatter::Serialize(CloudEvent cloud_event) {
+absl::StatusOr<StructuredCloudEvent> JsonFormatter::Serialize(
+        const CloudEvent& cloud_event) {
     // validate CloudEvent by ensuring all required metadata is present
     if (cloud_event.id().empty() || 
             cloud_event.source().empty() || 
@@ -88,15 +90,16 @@ absl::StatusOr<StructuredCloudEvent> JsonFormatter::Serialize(CloudEvent cloud_e
     return structured_ce;
 }
 
-absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(StructuredCloudEvent structured_cloud_event) {
+absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
+        const StructuredCloudEvent& structured_ce) {
     // Validate that this is the right format to be handled by this object
-    if (structured_cloud_event.format != Format::kJson) {
+    if (structured_ce.format != Format::kJson) {
         return absl::InternalError(
             "This structured cloud event is not JSON formatted and should not be handled by a Json Formatter.");
     }
 
     // Create a Json::Value from the serialization string
-    std::string serialization = structured_cloud_event.serialization;
+    std::string serialization = structured_ce.serialization;
     Json::CharReaderBuilder builder;
     Json::CharReader * reader = builder.newCharReader();
     std::string errors;

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -1,0 +1,12 @@
+#include "json_formatter.h"
+
+#include <google/protobuf/any.pb.h>
+#include <google/protobuf/message.h>
+#include <google/protobuf/util/json_util.h>
+#include <google/protobuf/util/time_util.h>
+
+namespace cloudevents {
+namespace format {
+
+} // format
+} // cloudevents

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -11,7 +11,7 @@ namespace cloudevents {
 namespace format {
 
 using ::io::cloudevents::v1::CloudEvent;
-using ::cloudevents::util::CloudEventsUtil;
+using ::cloudevents::cloudevents_util::CloudEventsUtil;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 using ::google::protobuf::util::TimeUtil;
 

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -8,5 +8,30 @@
 namespace cloudevents {
 namespace format {
 
+using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
+using ::google::protobuf::util::TimeUtil;
+
+absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(CloudEvent_CloudEventAttribute attr){    
+    switch (attr.attr_oneof_case()) {
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:
+            return Json::Value(attr.ce_boolean());
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeInteger:
+            return Json::Value(attr.ce_integer());
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeString:
+            return Json::Value(attr.ce_string());
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBinary:
+            return Json::Value(attr.ce_binary());
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeUri:
+            return Json::Value(attr.ce_uri());
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeUriReference:
+            return Json::Value(attr.ce_uri_reference());
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeTimestamp:
+            return Json::Value(TimeUtil::ToString(attr.ce_timestamp()));
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::ATTR_ONEOF_NOT_SET:
+            return absl::InvalidArgumentError("Cloud Event metadata attribute not set.");
+    }
+    return absl::InternalError("A Cloud Event attribute has not been handled.");
+}
+
 } // format
 } // cloudevents

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -8,8 +8,18 @@
 namespace cloudevents {
 namespace format {
 
+using ::io::cloudevents::v1::CloudEvent;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 using ::google::protobuf::util::TimeUtil;
+
+// TODO (#41): Move this to a CE Util, as it is used across formatters/ binders
+static constexpr absl::string_view kCeIdKey = "id";
+static constexpr absl::string_view kCeSourceKey = "source";
+static constexpr absl::string_view kCeSpecKey = "spec_version";
+static constexpr absl::string_view kCeTypeKey = "type";
+
+static constexpr absl::string_view kBinaryDataKey = "data_base64";
+static constexpr absl::string_view kJsonDataKey = "data";
 
 absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(CloudEvent_CloudEventAttribute attr){    
     switch (attr.attr_oneof_case()) {
@@ -31,6 +41,51 @@ absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(CloudEvent_CloudEventAttr
             return absl::InvalidArgumentError("Cloud Event metadata attribute not set.");
     }
     return absl::InternalError("A Cloud Event attribute has not been handled.");
+}
+
+absl::StatusOr<StructuredCloudEvent> JsonFormatter::Serialize(CloudEvent cloud_event) {
+    // validate CloudEvent by ensuring all required metadata is present
+    if (cloud_event.id().empty() || 
+            cloud_event.source().empty() || 
+            cloud_event.spec_version().empty() ||
+            cloud_event.type().empty()) {
+        return absl::InvalidArgumentError("Required attribute in Cloud Event cannot be empty");
+    }
+
+    Json::Value root;
+    root[kCeIdKey.data()] = cloud_event.id();
+    root[kCeSourceKey.data()] = cloud_event.source();
+    root[kCeSpecKey.data()] = cloud_event.spec_version();
+    root[kCeTypeKey.data()] = cloud_event.type();
+
+    for (auto const& attr : cloud_event.attributes()) {
+        absl::StatusOr<Json::Value> json_printed = PrintToJson(attr.second);
+        if (!json_printed.ok()) {
+            return json_printed.status();
+        }
+        root[attr.first] = (*json_printed);
+    }
+
+    switch (cloud_event.data_oneof_case()) {
+        case CloudEvent::DataOneofCase::kBinaryData:
+            root[kBinaryDataKey.data()] = cloud_event.binary_data();
+            break;
+        case CloudEvent::DataOneofCase::kTextData:
+            root[kJsonDataKey.data()] = cloud_event.text_data();
+            break;
+        case CloudEvent::DataOneofCase::kProtoData:
+            // TODO (#17): Handle CloudEvent Any in JsonFormatter
+            return absl::UnimplementedError("protobuf::Any not supported yet.");
+        case CloudEvent::DATA_ONEOF_NOT_SET:
+            break;
+    }
+
+    // Write JSON serialization as std::string
+    Json::StreamWriterBuilder builder;
+    StructuredCloudEvent structured_ce;
+    structured_ce.format = Format::kJson;
+    structured_ce.serialization = Json::writeString(builder, root);
+    return structured_ce;
 }
 
 } // format

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -15,6 +15,7 @@ using ::cloudevents::cloudevents_util::CloudEventsUtil;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 using ::google::protobuf::util::TimeUtil;
 
+typedef absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute> CeAttrMap;
 
 static constexpr absl::string_view kBinaryDataKey = "data_base64";
 static constexpr absl::string_view kJsonDataKey = "data";
@@ -49,7 +50,7 @@ absl::StatusOr<StructuredCloudEvent> JsonFormatter::Serialize(
         return absl::InvalidArgumentError("Required attribute in Cloud Event cannot be empty");
     }
 
-    absl::StatusOr<std::map<std::string, CloudEvent_CloudEventAttribute>> attrs;
+    absl::StatusOr<CeAttrMap> attrs;
     attrs = CloudEventsUtil::GetMetadata(cloud_event);
     if (!attrs.ok()) {
         return attrs.status();

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -15,11 +15,6 @@ using ::cloudevents::util::CloudEventsUtil;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 using ::google::protobuf::util::TimeUtil;
 
-// TODO (#41): Move this to a CE Util, as it is used across formatters/ binders
-static constexpr absl::string_view kCeIdKey = "id";
-static constexpr absl::string_view kCeSourceKey = "source";
-static constexpr absl::string_view kCeSpecKey = "spec_version";
-static constexpr absl::string_view kCeTypeKey = "type";
 
 static constexpr absl::string_view kBinaryDataKey = "data_base64";
 static constexpr absl::string_view kJsonDataKey = "data";
@@ -119,14 +114,15 @@ absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
 
     CloudEvent cloud_event;
     
+    // TODO (#39): Should we try to infer CE Type from serialization?
     for (auto const& member : root.getMemberNames()) {
-        if (member == kCeIdKey.data()) {
+        if (member == CloudEventsUtil::kCeIdKey.data()) {
             cloud_event.set_id(root[member].asString());
-        } else if (member == kCeSourceKey.data()) {
+        } else if (member == CloudEventsUtil::kCeSourceKey.data()) {
             cloud_event.set_source(root[member].asString());
-        } else if (member == kCeSpecKey.data()) {
+        } else if (member == CloudEventsUtil::kCeSpecKey.data()) {
             cloud_event.set_spec_version(root[member].asString());
-        } else if (member == kCeTypeKey.data()) {
+        } else if (member == CloudEventsUtil::kCeTypeKey.data()) {
             cloud_event.set_type(root[member].asString());
         } else {
             CloudEvent_CloudEventAttribute attr;

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -117,19 +117,7 @@ absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
     
     // TODO (#39): Should we try to infer CE Type from serialization?
     for (auto const& member : root.getMemberNames()) {
-        if (member == CloudEventsUtil::kCeIdKey.data()) {
-            cloud_event.set_id(root[member].asString());
-        } else if (member == CloudEventsUtil::kCeSourceKey.data()) {
-            cloud_event.set_source(root[member].asString());
-        } else if (member == CloudEventsUtil::kCeSpecKey.data()) {
-            cloud_event.set_spec_version(root[member].asString());
-        } else if (member == CloudEventsUtil::kCeTypeKey.data()) {
-            cloud_event.set_type(root[member].asString());
-        } else {
-            CloudEvent_CloudEventAttribute attr;
-            attr.set_ce_string(root[member].asString());
-            (*cloud_event.mutable_attributes())[member] = attr;
-        }
+        CloudEventsUtil::SetMetadata(&cloud_event, member, root[member].asString());
     }
 
     if (root.isMember(kJsonDataKey.data()) && root.isMember(kBinaryDataKey.data())) {

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -117,7 +117,7 @@ absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
     
     // TODO (#39): Should we try to infer CE Type from serialization?
     for (auto const& member : root.getMemberNames()) {
-        CloudEventsUtil::SetMetadata(&cloud_event, member, root[member].asString());
+        CloudEventsUtil::SetMetadata(cloud_event, member, root[member].asString());
     }
 
     if (root.isMember(kJsonDataKey.data()) && root.isMember(kBinaryDataKey.data())) {

--- a/v1/event_format/json_formatter.h
+++ b/v1/event_format/json_formatter.h
@@ -1,0 +1,34 @@
+#ifndef CLOUDEVENTCPPSDK_V1_EVENTFORMAT_JSONFORMATTER_H_
+#define CLOUDEVENTCPPSDK_V1_EVENTFORMAT_JSONFORMATTER_H_
+
+#include <json/json.h>
+
+#include "proto/cloud_event.pb.h"
+#include "third_party/statusor/statusor.h"
+#include "v1/event_format/formatter.h"
+#include "v1/event_format/structured_cloud_event.h"
+
+namespace cloudevents {
+namespace format {
+
+/*
+ * Implementation of Formatter for JSON EventFormat
+ */
+class JsonFormatter: public Formatter {
+    public: 
+        // Create Json-formatted serialization from CloudEvent
+        absl::StatusOr<StructuredCloudEvent> Serialize(io::cloudevents::v1::CloudEvent cloud_event) override;
+
+        // Create CloudEvent from Json-formatted serialization
+        absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(StructuredCloudEvent) override;
+
+    private:
+        // Convert from CE to JSON Type System according to https://github.com/cloudevents/spec/blob/master/json-format.md#22-type-system-mapping
+        // Relies mostly on the overloaded constructor for Json::Value in jsoncpp
+        absl::StatusOr<Json::Value> PrintToJson(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);
+};
+
+} // format
+} // cloudevents
+
+#endif //CLOUDEVENTCPPSDK_V1_EVENTFORMAT_JSONFORMATTER_H_

--- a/v1/event_format/json_formatter.h
+++ b/v1/event_format/json_formatter.h
@@ -17,15 +17,18 @@ namespace format {
 class JsonFormatter: public Formatter {
     public: 
         // Create Json-formatted serialization from CloudEvent
-        absl::StatusOr<StructuredCloudEvent> Serialize(io::cloudevents::v1::CloudEvent cloud_event) override;
+        absl::StatusOr<StructuredCloudEvent> Serialize(
+            const io::cloudevents::v1::CloudEvent& cloud_event) override;
 
         // Create CloudEvent from Json-formatted serialization
-        absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(StructuredCloudEvent) override;
+        absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
+            const StructuredCloudEvent& structured_ce) override;
 
     private:
         // Convert from CE to JSON Type System according to https://github.com/cloudevents/spec/blob/master/json-format.md#22-type-system-mapping
         // Relies mostly on the overloaded constructor for Json::Value in jsoncpp
-        absl::StatusOr<Json::Value> PrintToJson(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);
+        absl::StatusOr<Json::Value> PrintToJson(
+            const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
 };
 
 } // format

--- a/v1/event_format/json_formatter_test.cc
+++ b/v1/event_format/json_formatter_test.cc
@@ -80,8 +80,7 @@ TEST(Deserialize, BinaryData) {
     absl::StatusOr<CloudEvent> deserialize;
 
     deserialize = json_formatter.Deserialize(structured_ce);
-
-    ASSERT_TRUE(deserialize);
+    ASSERT_TRUE(deserialize.ok());
     ASSERT_EQ((*deserialize).id(), "9999999");
     ASSERT_EQ((*deserialize).source(), "/test/qwertyuiop");
     ASSERT_EQ((*deserialize).spec_version(), "3.xxxxx");
@@ -98,7 +97,7 @@ TEST(Deserialize, TextData) {
 
     deserialize = json_formatter.Deserialize(structured_ce);
 
-    ASSERT_TRUE(deserialize);
+    ASSERT_TRUE(deserialize.ok());
     ASSERT_EQ((*deserialize).id(), "9999999");
     ASSERT_EQ((*deserialize).source(), "/test/qwertyuiop");
     ASSERT_EQ((*deserialize).spec_version(), "4");

--- a/v1/event_format/json_formatter_test.cc
+++ b/v1/event_format/json_formatter_test.cc
@@ -1,0 +1,110 @@
+#include "json_formatter.h"
+#include <gtest/gtest.h>
+
+namespace cloudevents {
+namespace format {
+using ::io::cloudevents::v1::CloudEvent;
+using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
+
+TEST(Serialize, NoData) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+    JsonFormatter json_formatter;
+    absl::StatusOr<StructuredCloudEvent> serialize;
+
+    serialize = json_formatter.Serialize(cloud_event);
+    
+    ASSERT_TRUE(serialize.ok());
+    ASSERT_EQ((*serialize).format, Format::kJson);
+    ASSERT_EQ((*serialize).serialization,"{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}");
+}
+
+TEST(Serialize, BinaryData) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("4545");
+    cloud_event.set_source("/bonk+bonk");
+    cloud_event.set_spec_version("3.xxxxx");
+    cloud_event.set_type("new");
+    cloud_event.set_binary_data("0110");
+    JsonFormatter json_formatter;
+    absl::StatusOr<StructuredCloudEvent> serialize;
+
+    serialize = json_formatter.Serialize(cloud_event);
+
+    ASSERT_TRUE(serialize.ok());
+    ASSERT_EQ((*serialize).format, Format::kJson);
+    ASSERT_EQ((*serialize).serialization, "{\n\t\"data_base64\" : \"0110\",\n\t\"id\" : \"4545\",\n\t\"source\" : \"/bonk+bonk\",\n\t\"spec_version\" : \"3.xxxxx\",\n\t\"type\" : \"new\"\n}");
+}
+
+TEST(Serialize, TextData) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("9999999");
+    cloud_event.set_source("/test/qwertyuiop");
+    cloud_event.set_spec_version("4.xxxxx");
+    cloud_event.set_type("not_a_type");
+    cloud_event.set_text_data("this is text");
+    JsonFormatter json_formatter;
+    absl::StatusOr<StructuredCloudEvent> serialize;
+    
+    serialize = json_formatter.Serialize(cloud_event);
+
+    ASSERT_TRUE(serialize.ok());
+    ASSERT_EQ((*serialize).format, Format::kJson);
+    ASSERT_EQ((*serialize).serialization, "{\n\t\"data\" : \"this is text\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"4.xxxxx\",\n\t\"type\" : \"not_a_type\"\n}");
+}
+
+TEST(Deserialize, NoData) {
+    StructuredCloudEvent structured_ce;
+    structured_ce.format = Format::kJson;
+    structured_ce.serialization = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
+    JsonFormatter json_formatter;
+    absl::StatusOr<CloudEvent> deserialize;
+
+    deserialize = json_formatter.Deserialize(structured_ce);
+    
+    ASSERT_TRUE(deserialize.ok());
+    ASSERT_EQ((*deserialize).id(), "1");
+    ASSERT_EQ((*deserialize).source(), "/test");
+    ASSERT_EQ((*deserialize).spec_version(), "1.0");
+    ASSERT_EQ((*deserialize).type(), "test");
+}
+
+TEST(Deserialize, BinaryData) {
+    StructuredCloudEvent structured_ce;
+    structured_ce.format = Format::kJson;
+    structured_ce.serialization = "{\n\t\"data_base64\" : \"binary_data_wow\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"3.xxxxx\",\n\t\"type\" : \"not_a_type\"\n}";
+    JsonFormatter json_formatter;
+    absl::StatusOr<CloudEvent> deserialize;
+
+    deserialize = json_formatter.Deserialize(structured_ce);
+
+    ASSERT_TRUE(deserialize);
+    ASSERT_EQ((*deserialize).id(), "9999999");
+    ASSERT_EQ((*deserialize).source(), "/test/qwertyuiop");
+    ASSERT_EQ((*deserialize).spec_version(), "3.xxxxx");
+    ASSERT_EQ((*deserialize).type(), "not_a_type");
+    ASSERT_EQ((*deserialize).binary_data(), "binary_data_wow");
+}
+
+TEST(Deserialize, TextData) {
+    StructuredCloudEvent structured_ce;
+    structured_ce.format = Format::kJson;
+    structured_ce.serialization = "{\n\t\"data\" : \"this is text\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"4\",\n\t\"type\" : \"not_a_type\"\n}";
+    JsonFormatter json_formatter;
+    absl::StatusOr<CloudEvent> deserialize;
+
+    deserialize = json_formatter.Deserialize(structured_ce);
+
+    ASSERT_TRUE(deserialize);
+    ASSERT_EQ((*deserialize).id(), "9999999");
+    ASSERT_EQ((*deserialize).source(), "/test/qwertyuiop");
+    ASSERT_EQ((*deserialize).spec_version(), "4");
+    ASSERT_EQ((*deserialize).type(), "not_a_type");
+    ASSERT_EQ((*deserialize).text_data(), "this is text");
+}
+
+} // format
+} // cloudevents

--- a/v1/util/BUILD
+++ b/v1/util/BUILD
@@ -1,0 +1,25 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "cloud_events_util_lib",
+    srcs = ["cloud_events_util.cc"],
+    hdrs = [
+        "cloud_events_util.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party/statusor:statusor_lib",
+        "//third_party/base64:base64_lib",
+        "//proto:cloud_event_cc_proto",
+    ],
+)
+
+cc_test(
+   name = "cloud_events_util_test",
+   srcs = ["cloud_events_util_test.cc"],
+   deps = [
+       ":cloud_events_util_lib",
+       "@gtest//:gtest",
+       "@gtest//:gtest_main"
+   ],
+)

--- a/v1/util/BUILD
+++ b/v1/util/BUILD
@@ -8,6 +8,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
         "//third_party/statusor:statusor_lib",
         "//third_party/base64:base64_lib",
         "//proto:cloud_event_cc_proto",

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -41,6 +41,25 @@ absl::StatusOr<
     return attrs;
 }
 
+void CloudEventsUtil::SetMetadata(CloudEvent* cloud_event, 
+        std::string key, std::string value){
+    // TODO (#39): Should we try to infer CE Type from serialization?
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_string(value);
+    if (key == "id") {
+        cloud_event -> set_id(value);
+    } else if (key == "source") {
+        cloud_event -> set_source(value);
+    } else if (key == "spec_version") {
+        cloud_event -> set_spec_version(value);
+    } else if (key == "type") {
+        cloud_event -> set_type(value);
+    } else {
+        (*cloud_event -> mutable_attributes())[key] = attr;
+    }
+}
+
+
 absl::StatusOr<std::string> CloudEventsUtil::StringifyCeType(CloudEvent_CloudEventAttribute attr){
     switch (attr.attr_oneof_case()) {
         case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -8,6 +8,12 @@ namespace util {
 using ::io::cloudevents::v1::CloudEvent;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 
+bool CloudEventsUtil::IsValid(CloudEvent cloud_event) {
+    return !(cloud_event.id().empty() || 
+        cloud_event.source().empty() || 
+        cloud_event.spec_version().empty() ||
+        cloud_event.type().empty());
+}
 
 } // util
 } // cloudevents

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -41,6 +41,25 @@ absl::StatusOr<std::map<std::string, CloudEvent_CloudEventAttribute>> CloudEvent
     return attrs;
 }
 
+absl::StatusOr<std::string> CloudEventsUtil::StringifyCeType(CloudEvent_CloudEventAttribute attr){
+    switch (attr.attr_oneof_case()) {
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:
+            return std::string(attr.ce_boolean() ? "true" : "false");  // StatusOr requires explicit conversion
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeInteger:
+            return std::to_string(attr.ce_integer());  // skipping validity checks as protobuf generates int32 for sfixed32
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeString:
+            return attr.ce_string();
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBinary:
+            return base64::base64_encode(attr.ce_binary());
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeUri:
+            return attr.ce_uri();
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeUriReference:
+            return attr.ce_uri_reference();
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeTimestamp:
+            return google::protobuf::util::TimeUtil::ToString(attr.ce_timestamp());  // take advantage of protobuf using RFC3339 representation
+        case CloudEvent_CloudEventAttribute::AttrOneofCase::ATTR_ONEOF_NOT_SET:
+            return absl::InvalidArgumentError("Cloud Event metadata attribute not set.");
+    }
 }
 
 } // util

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -1,0 +1,13 @@
+#include "cloud_events_util.h"
+
+#include <google/protobuf/util/time_util.h>
+
+namespace cloudevents {
+namespace util {
+
+using ::io::cloudevents::v1::CloudEvent;
+using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
+
+
+} // util
+} // cloudevents

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -15,17 +15,17 @@ bool CloudEventsUtil::IsValid(CloudEvent cloud_event) {
         cloud_event.type().empty());
 }
 
-absl::StatusOr<std::map<std::string, CloudEvent_CloudEventAttribute>> CloudEventsUtil::GetMetadata(
-    CloudEvent cloud_event) {
+absl::StatusOr<
+        absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute>> 
+        CloudEventsUtil::GetMetadata(CloudEvent cloud_event) {
     if (!CloudEventsUtil::IsValid(cloud_event)) {
         return absl::InvalidArgumentError("GetMetadata can only be called with valid Cloud Event.");
     }
 
-    // create std::map from protobuf map of optional/ extensionattrs
-    std::map<std::string, CloudEvent_CloudEventAttribute> attrs(
+    // create absl::flat_hash_map from protobuf map of optional/ extensionattrs
+    absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute> attrs(
         (cloud_event.attributes()).begin(),
-        cloud_event.attributes().end()
-    );
+        cloud_event.attributes().end());
 
     // insert required attrs
     CloudEvent_CloudEventAttribute attr_val;

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -8,7 +8,7 @@ namespace cloudevents_util {
 using ::io::cloudevents::v1::CloudEvent;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 
-bool CloudEventsUtil::IsValid(CloudEvent& cloud_event) {
+bool CloudEventsUtil::IsValid(const CloudEvent& cloud_event) {
     return !(cloud_event.id().empty() || 
         cloud_event.source().empty() || 
         cloud_event.spec_version().empty() ||
@@ -17,7 +17,7 @@ bool CloudEventsUtil::IsValid(CloudEvent& cloud_event) {
 
 absl::StatusOr<
         absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute>> 
-        CloudEventsUtil::GetMetadata(CloudEvent& cloud_event) {
+        CloudEventsUtil::GetMetadata(const CloudEvent& cloud_event) {
     if (!CloudEventsUtil::IsValid(cloud_event)) {
         return absl::InvalidArgumentError("GetMetadata can only be called with valid Cloud Event.");
     }
@@ -60,7 +60,7 @@ void CloudEventsUtil::SetMetadata(CloudEvent& cloud_event,
 }
 
 
-absl::StatusOr<std::string> CloudEventsUtil::StringifyCeType(CloudEvent_CloudEventAttribute& attr){
+absl::StatusOr<std::string> CloudEventsUtil::StringifyCeType(const CloudEvent_CloudEventAttribute& attr){
     switch (attr.attr_oneof_case()) {
         case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:
             return std::string(attr.ce_boolean() ? "true" : "false");  // StatusOr requires explicit conversion

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -8,7 +8,7 @@ namespace cloudevents_util {
 using ::io::cloudevents::v1::CloudEvent;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 
-bool CloudEventsUtil::IsValid(CloudEvent cloud_event) {
+bool CloudEventsUtil::IsValid(CloudEvent& cloud_event) {
     return !(cloud_event.id().empty() || 
         cloud_event.source().empty() || 
         cloud_event.spec_version().empty() ||
@@ -17,7 +17,7 @@ bool CloudEventsUtil::IsValid(CloudEvent cloud_event) {
 
 absl::StatusOr<
         absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute>> 
-        CloudEventsUtil::GetMetadata(CloudEvent cloud_event) {
+        CloudEventsUtil::GetMetadata(CloudEvent& cloud_event) {
     if (!CloudEventsUtil::IsValid(cloud_event)) {
         return absl::InvalidArgumentError("GetMetadata can only be called with valid Cloud Event.");
     }
@@ -41,26 +41,26 @@ absl::StatusOr<
     return attrs;
 }
 
-void CloudEventsUtil::SetMetadata(CloudEvent* cloud_event, 
+void CloudEventsUtil::SetMetadata(CloudEvent& cloud_event, 
         std::string key, std::string value){
     // TODO (#39): Should we try to infer CE Type from serialization?
     CloudEvent_CloudEventAttribute attr;
     attr.set_ce_string(value);
     if (key == "id") {
-        cloud_event -> set_id(value);
+        cloud_event.set_id(value);
     } else if (key == "source") {
-        cloud_event -> set_source(value);
+        cloud_event.set_source(value);
     } else if (key == "spec_version") {
-        cloud_event -> set_spec_version(value);
+        cloud_event.set_spec_version(value);
     } else if (key == "type") {
-        cloud_event -> set_type(value);
+        cloud_event.set_type(value);
     } else {
-        (*cloud_event -> mutable_attributes())[key] = attr;
+        (*cloud_event.mutable_attributes())[key] = attr;
     }
 }
 
 
-absl::StatusOr<std::string> CloudEventsUtil::StringifyCeType(CloudEvent_CloudEventAttribute attr){
+absl::StatusOr<std::string> CloudEventsUtil::StringifyCeType(CloudEvent_CloudEventAttribute& attr){
     switch (attr.attr_oneof_case()) {
         case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:
             return std::string(attr.ce_boolean() ? "true" : "false");  // StatusOr requires explicit conversion

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -15,5 +15,33 @@ bool CloudEventsUtil::IsValid(CloudEvent cloud_event) {
         cloud_event.type().empty());
 }
 
+absl::StatusOr<std::map<std::string, CloudEvent_CloudEventAttribute>> CloudEventsUtil::GetMetadata(
+    CloudEvent cloud_event) {
+    if (!CloudEventsUtil::IsValid(cloud_event)) {
+        return absl::InvalidArgumentError("GetMetadata can only be called with valid Cloud Event.");
+    }
+
+    // create std::map from protobuf map of optional/ extensionattrs
+    std::map<std::string, CloudEvent_CloudEventAttribute> attrs(
+        (cloud_event.attributes()).begin(),
+        cloud_event.attributes().end()
+    );
+
+    // insert required attrs
+    CloudEvent_CloudEventAttribute attr_val;
+    attr_val.set_ce_string(cloud_event.id());
+    attrs["id"] = attr_val;
+    attr_val.set_ce_string(cloud_event.source());
+    attrs["source"] = attr_val;
+    attr_val.set_ce_string(cloud_event.spec_version());
+    attrs["spec_version"] = attr_val;
+    attr_val.set_ce_string(cloud_event.type());
+    attrs["type"] = attr_val;
+
+    return attrs;
+}
+
+}
+
 } // util
 } // cloudevents

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -79,6 +79,7 @@ absl::StatusOr<std::string> CloudEventsUtil::StringifyCeType(CloudEvent_CloudEve
         case CloudEvent_CloudEventAttribute::AttrOneofCase::ATTR_ONEOF_NOT_SET:
             return absl::InvalidArgumentError("Cloud Event metadata attribute not set.");
     }
+    return absl::InternalError("A CE type is not handled in StringifyCeType.");
 }
 
 } // util

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -3,7 +3,7 @@
 #include <google/protobuf/util/time_util.h>
 
 namespace cloudevents {
-namespace util {
+namespace cloudevents_util {
 
 using ::io::cloudevents::v1::CloudEvent;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -28,12 +28,6 @@ class CloudEventsUtil {
         // convert CloudEvent Attributes to their canonical string representaiton
         // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system
         static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);    
-
-        // Constexpr keys used when interacting with CloudEvent
-        inline static constexpr absl::string_view kCeIdKey = "id";
-        inline static constexpr absl::string_view kCeSourceKey = "source";
-        inline static constexpr absl::string_view kCeSpecKey = "spec_version";
-        inline static constexpr absl::string_view kCeTypeKey = "type";
 };
 
 } // util

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -12,12 +12,12 @@ namespace cloudevents_util {
 class CloudEventsUtil {
     public:
         // validate if given CloudEvent fulfills requirements to be valid
-        static bool IsValid(io::cloudevents::v1::CloudEvent& cloud_event);
+        static bool IsValid(const io::cloudevents::v1::CloudEvent& cloud_event);
 
         // get metadata from CloudEvent in a single map
         static absl::StatusOr<
             absl::flat_hash_map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
-        GetMetadata(io::cloudevents::v1::CloudEvent& cloud_event);
+        GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
 
         // TODO (#44): Overload SetMetadata to accept a map of attributes
         
@@ -27,7 +27,7 @@ class CloudEventsUtil {
 
         // convert CloudEvent Attributes to their canonical string representaiton
         // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system
-        static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);    
+        static absl::StatusOr<std::string> StringifyCeType(const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);    
 };
 
 } // util

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -22,11 +22,11 @@ class CloudEventsUtil {
         // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system
         static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);    
 
-        // // Constexpr keys used when interacting with CloudEvent
-        // inline static constexpr absl::string_view kCeIdKey = "id";
-        // inline static constexpr absl::string_view kCeSourceKey = "source";
-        // inline static constexpr absl::string_view kCeSpecKey = "spec_version";
-        // inline static constexpr absl::string_view kCeTypeKey = "type";
+        // Constexpr keys used when interacting with CloudEvent
+        inline static constexpr absl::string_view kCeIdKey = "id";
+        inline static constexpr absl::string_view kCeSourceKey = "source";
+        inline static constexpr absl::string_view kCeSpecKey = "spec_version";
+        inline static constexpr absl::string_view kCeTypeKey = "type";
 };
 
 } // util

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -13,10 +13,10 @@ class CloudEventsUtil {
         // validate if given CloudEvent fulfills requirements to be valid
         static bool IsValid(io::cloudevents::v1::CloudEvent cloud_event);
 
-        // // consolidate metadata in CloudEvent to a single map
-        // static absl::StatusOr<
-        //     std::map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
-        // GetMetadata(io::cloudevents::v1::CloudEvent cloud_event);
+        // consolidate metadata in CloudEvent to a single map
+        static absl::StatusOr<
+            std::map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
+        GetMetadata(io::cloudevents::v1::CloudEvent cloud_event);
 
         // // // convert CloudEvent Attributes to their canonical string representaiton
         // // // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -18,9 +18,9 @@ class CloudEventsUtil {
             std::map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
         GetMetadata(io::cloudevents::v1::CloudEvent cloud_event);
 
-        // // // convert CloudEvent Attributes to their canonical string representaiton
-        // // // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system
-        // static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);    
+        // convert CloudEvent Attributes to their canonical string representaiton
+        // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system
+        static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);    
 
         // // Constexpr keys used when interacting with CloudEvent
         // inline static constexpr absl::string_view kCeIdKey = "id";

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -6,7 +6,7 @@
 #include "proto/cloud_event.pb.h"
 
 namespace cloudevents {
-namespace util {
+namespace cloudevents_util {
 
 class CloudEventsUtil {
     public:

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -1,0 +1,35 @@
+#ifndef CLOUDEVENTSCPPSDK_V1_UTIL_CLOUDEVENTSUTIL
+#define CLOUDEVENTSCPPSDK_V1_UTIL_CLOUDEVENTSUTIL
+
+#include "third_party/statusor/statusor.h"
+#include "third_party/base64/base64.h"
+#include "proto/cloud_event.pb.h"
+
+namespace cloudevents {
+namespace util {
+
+class CloudEventsUtil {
+    public:
+        // // validate if given CloudEvent fulfills requirements to be valid
+        // static bool IsValid(io::cloudevents::v1::CloudEvent cloud_event);
+
+        // // consolidate metadata in CloudEvent to a single map
+        // static absl::StatusOr<
+        //     std::map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
+        // GetMetadata(io::cloudevents::v1::CloudEvent cloud_event);
+
+        // // // convert CloudEvent Attributes to their canonical string representaiton
+        // // // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system
+        // static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);    
+
+        // // Constexpr keys used when interacting with CloudEvent
+        // inline static constexpr absl::string_view kCeIdKey = "id";
+        // inline static constexpr absl::string_view kCeSourceKey = "source";
+        // inline static constexpr absl::string_view kCeSpecKey = "spec_version";
+        // inline static constexpr absl::string_view kCeTypeKey = "type";
+};
+
+} // util
+} // cloudevents
+
+#endif //CLOUDEVENTSCPPSDK_V1_UTIL_CLOUDEVENTSUTIL

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -12,22 +12,22 @@ namespace cloudevents_util {
 class CloudEventsUtil {
     public:
         // validate if given CloudEvent fulfills requirements to be valid
-        static bool IsValid(io::cloudevents::v1::CloudEvent cloud_event);
+        static bool IsValid(io::cloudevents::v1::CloudEvent& cloud_event);
 
         // get metadata from CloudEvent in a single map
         static absl::StatusOr<
             absl::flat_hash_map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
-        GetMetadata(io::cloudevents::v1::CloudEvent cloud_event);
+        GetMetadata(io::cloudevents::v1::CloudEvent& cloud_event);
 
         // TODO (#44): Overload SetMetadata to accept a map of attributes
         
         // set metadata in CloudEvent without dealing with CloudEvent proto structure
-        static void SetMetadata(io::cloudevents::v1::CloudEvent* cloud_event,
+        static void SetMetadata(io::cloudevents::v1::CloudEvent& cloud_event,
                 std::string key, std::string value);
 
         // convert CloudEvent Attributes to their canonical string representaiton
         // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system
-        static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);    
+        static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);    
 };
 
 } // util

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -19,6 +19,12 @@ class CloudEventsUtil {
             absl::flat_hash_map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
         GetMetadata(io::cloudevents::v1::CloudEvent cloud_event);
 
+        // TODO (#44): Overload SetMetadata to accept a map of attributes
+        
+        // set metadata in CloudEvent without dealing with CloudEvent proto structure
+        static void SetMetadata(io::cloudevents::v1::CloudEvent* cloud_event,
+                std::string key, std::string value);
+
         // convert CloudEvent Attributes to their canonical string representaiton
         // as per outlined in https://github.com/cloudevents/spec/blob/master/spec.md#type-system
         static absl::StatusOr<std::string> StringifyCeType(io::cloudevents::v1::CloudEvent_CloudEventAttribute attr);    

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -10,8 +10,8 @@ namespace util {
 
 class CloudEventsUtil {
     public:
-        // // validate if given CloudEvent fulfills requirements to be valid
-        // static bool IsValid(io::cloudevents::v1::CloudEvent cloud_event);
+        // validate if given CloudEvent fulfills requirements to be valid
+        static bool IsValid(io::cloudevents::v1::CloudEvent cloud_event);
 
         // // consolidate metadata in CloudEvent to a single map
         // static absl::StatusOr<

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -1,6 +1,7 @@
 #ifndef CLOUDEVENTSCPPSDK_V1_UTIL_CLOUDEVENTSUTIL
 #define CLOUDEVENTSCPPSDK_V1_UTIL_CLOUDEVENTSUTIL
 
+#include "absl/container/flat_hash_map.h"
 #include "third_party/statusor/statusor.h"
 #include "third_party/base64/base64.h"
 #include "proto/cloud_event.pb.h"
@@ -13,9 +14,9 @@ class CloudEventsUtil {
         // validate if given CloudEvent fulfills requirements to be valid
         static bool IsValid(io::cloudevents::v1::CloudEvent cloud_event);
 
-        // consolidate metadata in CloudEvent to a single map
+        // get metadata from CloudEvent in a single map
         static absl::StatusOr<
-            std::map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
+            absl::flat_hash_map<std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
         GetMetadata(io::cloudevents::v1::CloudEvent cloud_event);
 
         // convert CloudEvent Attributes to their canonical string representaiton

--- a/v1/util/cloud_events_util_test.cc
+++ b/v1/util/cloud_events_util_test.cc
@@ -2,7 +2,6 @@
 #include <google/protobuf/timestamp.pb.h>
 #include <google/protobuf/util/time_util.h>
 #include <gtest/gtest.h>
-#include <iostream>
 
 namespace cloudevents {
 namespace cloudevents_util {
@@ -120,6 +119,47 @@ TEST(CloudEventsUtilTest, GetMetadata_TwoOptional) {
     ASSERT_TRUE((*get_metadata)["type"].ce_string() == "test");
     ASSERT_TRUE((*get_metadata)["test_key1"].ce_string() == "test_val1");
     ASSERT_TRUE((*get_metadata)["test_key2"].ce_string() == "test_val2");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_Id) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata(&cloud_event, "id", "1");
+
+    ASSERT_EQ(cloud_event.id(), "1");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_Source) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata(&cloud_event, "source", "/a_source");
+
+    ASSERT_EQ(cloud_event.source(), "/a_source");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_SpecVersion) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata(&cloud_event, "spec_version", "1.xx");
+
+    ASSERT_EQ(cloud_event.spec_version(), "1.xx");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_Type) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata(&cloud_event, "type", "test");
+
+    ASSERT_EQ(cloud_event.type(), "test");
+}
+
+TEST(CloudEventsUtilTest, SetMetadata_Optional) {
+    CloudEvent cloud_event;
+
+    CloudEventsUtil::SetMetadata(&cloud_event, "opt", "arbitrary");
+
+    CloudEvent_CloudEventAttribute attr = cloud_event.attributes().at("opt");
+    ASSERT_EQ(attr.ce_string(), "arbitrary");
 }
 
 TEST(CloudEventsUtilTest, StringifyCeType_BoolFalse) {

--- a/v1/util/cloud_events_util_test.cc
+++ b/v1/util/cloud_events_util_test.cc
@@ -5,7 +5,7 @@
 #include <iostream>
 
 namespace cloudevents {
-namespace util {
+namespace cloudevents_util {
 
 using ::io::cloudevents::v1::CloudEvent;
 using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;

--- a/v1/util/cloud_events_util_test.cc
+++ b/v1/util/cloud_events_util_test.cc
@@ -124,7 +124,7 @@ TEST(CloudEventsUtilTest, GetMetadata_TwoOptional) {
 TEST(CloudEventsUtilTest, SetMetadata_Id) {
     CloudEvent cloud_event;
 
-    CloudEventsUtil::SetMetadata(&cloud_event, "id", "1");
+    CloudEventsUtil::SetMetadata(cloud_event, "id", "1");
 
     ASSERT_EQ(cloud_event.id(), "1");
 }
@@ -132,7 +132,7 @@ TEST(CloudEventsUtilTest, SetMetadata_Id) {
 TEST(CloudEventsUtilTest, SetMetadata_Source) {
     CloudEvent cloud_event;
 
-    CloudEventsUtil::SetMetadata(&cloud_event, "source", "/a_source");
+    CloudEventsUtil::SetMetadata(cloud_event, "source", "/a_source");
 
     ASSERT_EQ(cloud_event.source(), "/a_source");
 }
@@ -140,7 +140,7 @@ TEST(CloudEventsUtilTest, SetMetadata_Source) {
 TEST(CloudEventsUtilTest, SetMetadata_SpecVersion) {
     CloudEvent cloud_event;
 
-    CloudEventsUtil::SetMetadata(&cloud_event, "spec_version", "1.xx");
+    CloudEventsUtil::SetMetadata(cloud_event, "spec_version", "1.xx");
 
     ASSERT_EQ(cloud_event.spec_version(), "1.xx");
 }
@@ -148,7 +148,7 @@ TEST(CloudEventsUtilTest, SetMetadata_SpecVersion) {
 TEST(CloudEventsUtilTest, SetMetadata_Type) {
     CloudEvent cloud_event;
 
-    CloudEventsUtil::SetMetadata(&cloud_event, "type", "test");
+    CloudEventsUtil::SetMetadata(cloud_event, "type", "test");
 
     ASSERT_EQ(cloud_event.type(), "test");
 }
@@ -156,7 +156,7 @@ TEST(CloudEventsUtilTest, SetMetadata_Type) {
 TEST(CloudEventsUtilTest, SetMetadata_Optional) {
     CloudEvent cloud_event;
 
-    CloudEventsUtil::SetMetadata(&cloud_event, "opt", "arbitrary");
+    CloudEventsUtil::SetMetadata(cloud_event, "opt", "arbitrary");
 
     CloudEvent_CloudEventAttribute attr = cloud_event.attributes().at("opt");
     ASSERT_EQ(attr.ce_string(), "arbitrary");

--- a/v1/util/cloud_events_util_test.cc
+++ b/v1/util/cloud_events_util_test.cc
@@ -1,0 +1,215 @@
+#include "cloud_events_util.h"
+#include <google/protobuf/timestamp.pb.h>
+#include <google/protobuf/util/time_util.h>
+#include <gtest/gtest.h>
+#include <iostream>
+
+namespace cloudevents {
+namespace util {
+
+using ::io::cloudevents::v1::CloudEvent;
+using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
+using ::google::protobuf::Timestamp;
+using ::google::protobuf::util::TimeUtil;
+
+typedef std::map<std::string, CloudEvent_CloudEventAttribute> CeAttrMap;
+
+TEST(CloudEventsUtilTest, IsValid_NoSource) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+
+    ASSERT_FALSE(CloudEventsUtil::IsValid(cloud_event));
+}
+
+TEST(CloudEventsUtilTest, IsValid_NoSpecVersion) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_type("test");
+
+    ASSERT_FALSE(CloudEventsUtil::IsValid(cloud_event));
+}
+
+TEST(CloudEventsUtilTest, IsValid_NoType) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+
+    ASSERT_FALSE(CloudEventsUtil::IsValid(cloud_event));
+}
+
+TEST(CloudEventsUtilTest, IsValid_HasRequired) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+
+    ASSERT_TRUE(CloudEventsUtil::IsValid(cloud_event));
+}
+
+TEST(CloudEventsUtilTest, GetMetadata_InvalidCloudEvent) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    absl::Status get_metadata_status;
+
+    get_metadata_status = CloudEventsUtil::GetMetadata(cloud_event).status();
+    
+    ASSERT_TRUE(absl::IsInvalidArgument(get_metadata_status));
+}
+
+TEST(CloudEventsUtilTest, GetMetadata_NoOptional) {
+    // setup input to function
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+
+    absl::StatusOr<CeAttrMap> get_metadata = CloudEventsUtil::GetMetadata(cloud_event);
+
+    ASSERT_TRUE(get_metadata.ok());
+    ASSERT_TRUE((*get_metadata)["id"].ce_string() == "1");
+    ASSERT_TRUE((*get_metadata)["source"].ce_string() == "/test");
+    ASSERT_TRUE((*get_metadata)["spec_version"].ce_string() == "1.0");
+    ASSERT_TRUE((*get_metadata)["type"].ce_string() == "test");
+}
+
+
+TEST(CloudEventsUtilTest, GetMetadata_OneOptional) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_string("test_val");
+    (*cloud_event.mutable_attributes())["test_key"] = attr;
+
+    absl::StatusOr<CeAttrMap> get_metadata = CloudEventsUtil::GetMetadata(cloud_event);
+    ASSERT_TRUE(get_metadata.ok());
+    ASSERT_TRUE((*get_metadata)["id"].ce_string() == "1");
+    ASSERT_TRUE((*get_metadata)["source"].ce_string() == "/test");
+    ASSERT_TRUE((*get_metadata)["spec_version"].ce_string() == "1.0");
+    ASSERT_TRUE((*get_metadata)["type"].ce_string() == "test");
+    ASSERT_TRUE((*get_metadata)["test_key"].ce_string() == "test_val");
+}
+
+TEST(CloudEventsUtilTest, GetMetadata_TwoOptional) {
+    CloudEvent cloud_event;
+    cloud_event.set_id("1");
+    cloud_event.set_source("/test");
+    cloud_event.set_spec_version("1.0");
+    cloud_event.set_type("test");
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_string("test_val1");
+    (*cloud_event.mutable_attributes())["test_key1"] = attr;
+    attr.set_ce_string("test_val2");
+    (*cloud_event.mutable_attributes())["test_key2"] = attr;
+
+    absl::StatusOr<CeAttrMap> get_metadata = CloudEventsUtil::GetMetadata(cloud_event);
+    ASSERT_TRUE(get_metadata.ok());
+    ASSERT_TRUE((*get_metadata)["id"].ce_string() == "1");
+    ASSERT_TRUE((*get_metadata)["source"].ce_string() == "/test");
+    ASSERT_TRUE((*get_metadata)["spec_version"].ce_string() == "1.0");
+    ASSERT_TRUE((*get_metadata)["type"].ce_string() == "test");
+    ASSERT_TRUE((*get_metadata)["test_key1"].ce_string() == "test_val1");
+    ASSERT_TRUE((*get_metadata)["test_key2"].ce_string() == "test_val2");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_BoolFalse) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_boolean(false);
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "false");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_BoolTrue) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_boolean(true);
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "true");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_Integer) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_integer(88);
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "88");
+}
+
+
+TEST(CloudEventsUtilTest, StringifyCeType_String) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_string("test");
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "test");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_URI) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_uri("https://google.com");
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "https://google.com");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_URIRef) {
+    CloudEvent_CloudEventAttribute attr;
+    attr.set_ce_uri_reference("https://www.google.com/#fragment");
+    absl::StatusOr<std::string> stringify_ce_type;
+
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(stringify_ce_type.ok());
+    ASSERT_EQ((*stringify_ce_type), "https://www.google.com/#fragment");
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_Timestamp) {
+    Timestamp timestamp = TimeUtil::GetCurrentTime();
+    std::string timestamp_str = TimeUtil::ToString(timestamp);
+    CloudEvent_CloudEventAttribute attr;
+    attr.mutable_ce_timestamp()-> MergeFrom(timestamp);
+    absl::StatusOr<std::string> stringify_ce_type;
+    
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_EQ((*stringify_ce_type), timestamp_str);
+}
+
+TEST(CloudEventsUtilTest, StringifyCeType_NotSet) {
+    CloudEvent_CloudEventAttribute attr;
+    absl::StatusOr<std::string> stringify_ce_type;
+    
+    stringify_ce_type = CloudEventsUtil::StringifyCeType(attr);
+
+    ASSERT_TRUE(absl::IsInvalidArgument(stringify_ce_type.status()));
+}
+
+
+} // util
+} // cloudevents

--- a/v1/util/cloud_events_util_test.cc
+++ b/v1/util/cloud_events_util_test.cc
@@ -12,7 +12,7 @@ using ::io::cloudevents::v1::CloudEvent_CloudEventAttribute;
 using ::google::protobuf::Timestamp;
 using ::google::protobuf::util::TimeUtil;
 
-typedef std::map<std::string, CloudEvent_CloudEventAttribute> CeAttrMap;
+typedef absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute> CeAttrMap;
 
 TEST(CloudEventsUtilTest, IsValid_NoSource) {
     CloudEvent cloud_event;


### PR DESCRIPTION
[View changes unique to this PR - *for developmental feedback only!*](https://github.com/googleinterns/cloudevents-sdk-cpp/pull/40/files/bf691a5dff7a8e0224a614a57373fd21abac3378..873afcdba7e5224222a1f0a35704f25965a6da04)
**When merging, any changes from "nested" PRs will also be merged, hence all changes shown in `Files changed` will be merged. PRs with lower "stage" values should be merged first!**
_________

[Relevant documentation](https://doc___s.google.com/document/d/1FbVf5VeoREwFvk0SnVPpkHn_JAuZcrXuoo6AJnhuLVg/edit#bookmark=id.rep7w8ot75qd)

- encapsulate logic that is commonly used for interacting with CloudEvents. Particularly logic that will be repeated over different marshallers and binders
- refactored json formatter to use these util funcs
- fixes #41 and #27 

- [x] Tests pass
- [x] Documentation for non-api code in header files