### PR TITLE
[Stage 1] Binder HTTP

### DIFF
--- a/v1/protocol_binding/BUILD
+++ b/v1/protocol_binding/BUILD
@@ -27,6 +27,10 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@boost//:beast",
+        "//proto:cloud_event_cc_proto",
+        "//third_party/statusor:statusor_lib",
+        "//v1/util:binder_util_lib",
+        "//v1/util:cloud_events_util_lib",
         ":binder_lib",
     ],
 )

--- a/v1/protocol_binding/BUILD
+++ b/v1/protocol_binding/BUILD
@@ -15,3 +15,28 @@ cc_library(
 
     ],
 )
+
+cc_library(
+    name = "http_binder_lib",
+    srcs = [
+        "http_binder.cc"
+    ],
+    hdrs = [
+        "http_binder.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@boost//:beast",
+        ":binder_lib",
+    ],
+)
+
+cc_test(
+   name = "http_binder_test",
+   srcs = ["http_binder_test.cc"],
+   deps = [
+       ":http_binder_lib",
+       "@gtest//:gtest",
+       "@gtest//:gtest_main"
+   ],
+)

--- a/v1/protocol_binding/http_binder.cc
+++ b/v1/protocol_binding/http_binder.cc
@@ -1,8 +1,7 @@
 #include "http_binder.h"
 
-#include "third_party/statusor/statusor.h"
-#include "proto/cloud_event.pb.h"
 #include "v1/util/binder_util.h"
+#include "v1/util/cloud_events_util.h"
 
 namespace cloudevents {
 namespace binding {

--- a/v1/protocol_binding/http_binder.cc
+++ b/v1/protocol_binding/http_binder.cc
@@ -51,5 +51,21 @@ Status HttpBinder<IsReq>::BindDataText(const std::string& text_data,
   return OkStatus();
 }
 
+// _____ Operations used in Bind Structured _____
+
+template <bool IsReq>
+Status HttpBinder<IsReq>::BindContentType(const std::string& contenttype,
+    message<IsReq, string_body>& http_msg) {
+  http_msg.base().set(kHttpContentKey, contenttype);
+  return OkStatus();
+}
+
+template <bool IsReq>
+Status HttpBinder<IsReq>::BindDataStructured(const std::string& payload,
+    message<IsReq, string_body>& http_msg) {
+  http_msg.body() = payload;
+  return OkStatus();
+}
+
 }  // namespace binding
 }  // namespace cloudevents

--- a/v1/protocol_binding/http_binder.cc
+++ b/v1/protocol_binding/http_binder.cc
@@ -1,0 +1,26 @@
+#include "http_binder.h"
+
+#include "third_party/statusor/statusor.h"
+#include "proto/cloud_event.pb.h"
+#include "v1/util/binder_util.h"
+
+namespace cloudevents {
+namespace binding {
+
+using ::absl::Status;
+using ::absl::OkStatus;
+using ::cloudevents_absl::StatusOr;
+using ::io::cloudevents::v1::CloudEvent;
+using ::cloudevents::cloudevents_util::CloudEventsUtil;
+using ::cloudevents::binder_util::BinderUtil;
+using ::boost::beast::http::message;
+using ::boost::beast::http::string_body;
+
+typedef io::cloudevents::v1::CloudEvent_CloudEventAttribute CeAttr;
+typedef absl::flat_hash_map<std::string, CeAttr> CeAttrMap;
+
+static const char kHttpContentKey[] = "Content-Type";
+static const char kErrAmbiguousContentMode[] = "Given Http Message contains indicators for both Binary and Structured Content Mode.";
+
+}  // namespace binding
+}  // namespace cloudevents

--- a/v1/protocol_binding/http_binder.cc
+++ b/v1/protocol_binding/http_binder.cc
@@ -123,5 +123,9 @@ StatusOr<std::string> HttpBinder<IsReq>::GetPayload(
   return http_msg.body();
 }
 
+// _____ explicit instantiations _____
+template class HttpBinder<true>;
+template class HttpBinder<false>;
+
 }  // namespace binding
 }  // namespace cloudevents

--- a/v1/protocol_binding/http_binder.cc
+++ b/v1/protocol_binding/http_binder.cc
@@ -94,7 +94,7 @@ template <bool IsReq>
 Status HttpBinder<IsReq>::UnbindData(
     const message<IsReq, string_body>& http_msg, CloudEvent& cloud_event) {
   if (!http_msg.body().empty()) {
-    cloud_event.set_text_data(http_msg.body());
+    cloud_event.set_binary_data(http_msg.body());
   }
   return OkStatus();
 }

--- a/v1/protocol_binding/http_binder.cc
+++ b/v1/protocol_binding/http_binder.cc
@@ -99,5 +99,29 @@ Status HttpBinder<IsReq>::UnbindData(
   return OkStatus();
 }
 
+// _____ Operations used in Unbind Structured _____
+
+template <bool IsReq>
+StatusOr<std::string> HttpBinder<IsReq>::GetContentType(
+    const message<IsReq, string_body>& http_msg) {
+  auto iter = http_msg.base().find(kHttpContentKey);
+  if (iter == http_msg.base().end()) {
+    // If kHttpContentKey not present, Binary-ContentMode
+    // StatusOr<> requires explicit typecasting
+    return std::string("");
+  }
+  // kHttpContentKey and ce-datacontenttype should be mutually exclusive
+  if (http_msg.base().find("ce-datacontenttype") != http_msg.base().end()) {
+    return absl::InvalidArgumentError(kErrAmbiguousContentMode);
+  }
+  return std::string(iter->value());
+}
+
+template <bool IsReq>
+StatusOr<std::string> HttpBinder<IsReq>::GetPayload(
+    const message<IsReq, string_body>& http_msg) {
+  return http_msg.body();
+}
+
 }  // namespace binding
 }  // namespace cloudevents

--- a/v1/protocol_binding/http_binder.cc
+++ b/v1/protocol_binding/http_binder.cc
@@ -7,9 +7,6 @@
 namespace cloudevents {
 namespace binding {
 
-using ::absl::Status;
-using ::absl::OkStatus;
-using ::cloudevents_absl::StatusOr;
 using ::io::cloudevents::v1::CloudEvent;
 using ::cloudevents::cloudevents_util::CloudEventsUtil;
 using ::cloudevents::binder_util::BinderUtil;
@@ -25,52 +22,53 @@ static const char kErrAmbiguousContentMode[] = "Given Http Message contains indi
 // _____ Operations used in Bind Binary _____
 
 template <bool IsReq>
-Status HttpBinder<IsReq>::BindMetadata(const std::string& key,
+absl::Status HttpBinder<IsReq>::BindMetadata(const std::string& key,
     const CeAttr& val, message<IsReq, string_body>& http_msg) {
-  StatusOr<std::string> val_str = CloudEventsUtil::ToString(val);
+  cloudevents_absl::StatusOr<std::string> val_str =
+    CloudEventsUtil::ToString(val);
   if (!val_str.ok()) {
     return val_str.status();
   }
   http_msg.base().set(key, *val_str);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 template <bool IsReq>
-Status HttpBinder<IsReq>::BindDataBinary(const std::string& bin_data,
+absl::Status HttpBinder<IsReq>::BindDataBinary(const std::string& bin_data,
     message<IsReq, string_body>& http_msg) {
   // spec states to place data into body as is
   http_msg.body() = bin_data;
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 template <bool IsReq>
-Status HttpBinder<IsReq>::BindDataText(const std::string& text_data,
+absl::Status HttpBinder<IsReq>::BindDataText(const std::string& text_data,
     message<IsReq, string_body>& http_msg) {
   // spec states to place data into body as is
   http_msg.body() = text_data;
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // _____ Operations used in Bind Structured _____
 
 template <bool IsReq>
-Status HttpBinder<IsReq>::BindContentType(const std::string& contenttype,
+absl::Status HttpBinder<IsReq>::BindContentType(const std::string& contenttype,
     message<IsReq, string_body>& http_msg) {
   http_msg.base().set(kHttpContentKey, contenttype);
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 template <bool IsReq>
-Status HttpBinder<IsReq>::BindDataStructured(const std::string& payload,
+absl::Status HttpBinder<IsReq>::BindDataStructured(const std::string& payload,
     message<IsReq, string_body>& http_msg) {
   http_msg.body() = payload;
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // _____ Operations used in Unbind Binary _____
 
 template <bool IsReq>
-Status HttpBinder<IsReq>::UnbindMetadata(
+absl::Status HttpBinder<IsReq>::UnbindMetadata(
     const message<IsReq, string_body>& http_msg, CloudEvent& cloud_event) {
   for (auto it = http_msg.base().begin(); it != http_msg.base().end(); ++it) {
     std::string header_key = (*it).name_string().to_string();
@@ -87,27 +85,27 @@ Status HttpBinder<IsReq>::UnbindMetadata(
       }
     }
   }
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 template <bool IsReq>
-Status HttpBinder<IsReq>::UnbindData(
+absl::Status HttpBinder<IsReq>::UnbindData(
     const message<IsReq, string_body>& http_msg, CloudEvent& cloud_event) {
   if (!http_msg.body().empty()) {
     cloud_event.set_binary_data(http_msg.body());
   }
-  return OkStatus();
+  return absl::OkStatus();
 }
 
 // _____ Operations used in Unbind Structured _____
 
 template <bool IsReq>
-StatusOr<std::string> HttpBinder<IsReq>::GetContentType(
+cloudevents_absl::StatusOr<std::string> HttpBinder<IsReq>::GetContentType(
     const message<IsReq, string_body>& http_msg) {
   auto iter = http_msg.base().find(kHttpContentKey);
   if (iter == http_msg.base().end()) {
     // If kHttpContentKey not present, Binary-ContentMode
-    // StatusOr<> requires explicit typecasting
+    // cloudevents_absl::StatusOr<> requires explicit typecasting
     return std::string("");
   }
   // kHttpContentKey and ce-datacontenttype should be mutually exclusive
@@ -118,7 +116,7 @@ StatusOr<std::string> HttpBinder<IsReq>::GetContentType(
 }
 
 template <bool IsReq>
-StatusOr<std::string> HttpBinder<IsReq>::GetPayload(
+cloudevents_absl::StatusOr<std::string> HttpBinder<IsReq>::GetPayload(
     const message<IsReq, string_body>& http_msg) {
   return http_msg.body();
 }

--- a/v1/protocol_binding/http_binder.cc
+++ b/v1/protocol_binding/http_binder.cc
@@ -22,5 +22,34 @@ typedef absl::flat_hash_map<std::string, CeAttr> CeAttrMap;
 static const char kHttpContentKey[] = "Content-Type";
 static const char kErrAmbiguousContentMode[] = "Given Http Message contains indicators for both Binary and Structured Content Mode.";
 
+// _____ Operations used in Bind Binary _____
+
+template <bool IsReq>
+Status HttpBinder<IsReq>::BindMetadata(const std::string& key,
+    const CeAttr& val, message<IsReq, string_body>& http_msg) {
+  StatusOr<std::string> val_str = CloudEventsUtil::ToString(val);
+  if (!val_str.ok()) {
+    return val_str.status();
+  }
+  http_msg.base().set(key, *val_str);
+  return OkStatus();
+}
+
+template <bool IsReq>
+Status HttpBinder<IsReq>::BindDataBinary(const std::string& bin_data,
+    message<IsReq, string_body>& http_msg) {
+  // spec states to place data into body as is
+  http_msg.body() = bin_data;
+  return OkStatus();
+}
+
+template <bool IsReq>
+Status HttpBinder<IsReq>::BindDataText(const std::string& text_data,
+    message<IsReq, string_body>& http_msg) {
+  // spec states to place data into body as is
+  http_msg.body() = text_data;
+  return OkStatus();
+}
+
 }  // namespace binding
 }  // namespace cloudevents

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -69,6 +69,10 @@ class HttpBinder: public Binder<
     IsReq, boost::beast::http::string_body>& http_msg) override;
 };
 
+// _____ Concrete Binders _____
+class HttpReqBinder: public HttpBinder<true> {};
+class HttpResBinder: public HttpBinder<false> {};
+
 }  // namespace binding
 }  // namespace cloudevents
 

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -23,8 +23,6 @@ template <bool IsReq>
 class HttpBinder: public Binder<
   boost::beast::http::message<IsReq, boost::beast::http::string_body>> {
  private:
-  // _____ Operations used in Bind Binary _____
-
   absl::Status BindMetadata(const std::string& key,
     const io::cloudevents::v1::CloudEvent_CloudEventAttribute& val,
     boost::beast::http::message<
@@ -34,12 +32,9 @@ class HttpBinder: public Binder<
     boost::beast::http::message<
     IsReq, boost::beast::http::string_body>& http_msg) override;
 
-
   absl::Status BindDataText(const std::string& text_data,
     boost::beast::http::message<
     IsReq, boost::beast::http::string_body>& http_msg) override;
-
-  // _____ Operations used in Bind Structured _____
 
   absl::Status BindContentType(const std::string& contenttype,
     boost::beast::http::message<
@@ -48,8 +43,6 @@ class HttpBinder: public Binder<
   absl::Status BindDataStructured(const std::string& payload,
     boost::beast::http::message<
     IsReq, boost::beast::http::string_body>& http_msg) override;
-
-  // _____ Operations used in Unbind Binary _____
 
   absl::Status UnbindMetadata(
     const boost::beast::http::message<
@@ -60,8 +53,6 @@ class HttpBinder: public Binder<
     const boost::beast::http::message<
     IsReq, boost::beast::http::string_body>& http_msg,
     io::cloudevents::v1::CloudEvent& cloud_event) override;
-
-  // _____ Operations used in Unbind Structured _____
 
   cloudevents_absl::StatusOr<std::string> GetContentType(
     const boost::beast::http::message<

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -46,6 +46,18 @@ class HttpBinder: public Binder<
     boost::beast::http::message<
     IsReq, boost::beast::http::string_body>& http_msg) override;
 
+  // _____ Operations used in Unbind Binary _____
+
+  absl::Status UnbindMetadata(
+    const boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg,
+    io::cloudevents::v1::CloudEvent& cloud_event) override;
+
+  absl::Status UnbindData(
+    const boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg,
+    io::cloudevents::v1::CloudEvent& cloud_event) override;
+
 }  // namespace binding
 }  // namespace cloudevents
 

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -58,6 +58,17 @@ class HttpBinder: public Binder<
     IsReq, boost::beast::http::string_body>& http_msg,
     io::cloudevents::v1::CloudEvent& cloud_event) override;
 
+  // _____ Operations used in Unbind Structured _____
+
+  cloudevents_absl::StatusOr<std::string> GetContentType(
+    const boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg) override;
+
+  cloudevents_absl::StatusOr<std::string> GetPayload(
+    const boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg) override;
+};
+
 }  // namespace binding
 }  // namespace cloudevents
 

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -20,6 +20,21 @@ template <bool IsReq>
 class HttpBinder: public Binder<
   boost::beast::http::message<IsReq, boost::beast::http::string_body>> {
  private:
+  // _____ Operations used in Bind Binary _____
+
+  absl::Status BindMetadata(const std::string& key,
+    const io::cloudevents::v1::CloudEvent_CloudEventAttribute& val,
+    boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg) override;
+
+  absl::Status BindDataBinary(const std::string& bin_data,
+    boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg) override;
+
+
+  absl::Status BindDataText(const std::string& text_data,
+    boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg) override;
 
 }  // namespace binding
 }  // namespace cloudevents

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -2,6 +2,9 @@
 #define CLOUDEVENTSCPPSDK_V1_BINDING_HTTPBINDER_H
 
 #include <boost/beast/http.hpp>
+
+#include "proto/cloud_event.pb.h"
+#include "third_party/statusor/statusor.h"
 #include "v1/protocol_binding/binder.h"
 
 namespace cloudevents {

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -70,8 +70,9 @@ class HttpBinder: public Binder<
 };
 
 // _____ Concrete Binders _____
-class HttpReqBinder: public HttpBinder<true> {};
-class HttpResBinder: public HttpBinder<false> {};
+using HttpReqBinder = HttpBinder<true>;
+using HttpResBinder = HttpBinder<false>;
+
 
 }  // namespace binding
 }  // namespace cloudevents

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -36,6 +36,16 @@ class HttpBinder: public Binder<
     boost::beast::http::message<
     IsReq, boost::beast::http::string_body>& http_msg) override;
 
+  // _____ Operations used in Bind Structured _____
+
+  absl::Status BindContentType(const std::string& contenttype,
+    boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg) override;
+
+  absl::Status BindDataStructured(const std::string& payload,
+    boost::beast::http::message<
+    IsReq, boost::beast::http::string_body>& http_msg) override;
+
 }  // namespace binding
 }  // namespace cloudevents
 

--- a/v1/protocol_binding/http_binder.h
+++ b/v1/protocol_binding/http_binder.h
@@ -1,0 +1,27 @@
+#ifndef CLOUDEVENTSCPPSDK_V1_BINDING_HTTPBINDER_H
+#define CLOUDEVENTSCPPSDK_V1_BINDING_HTTPBINDER_H
+
+#include <boost/beast/http.hpp>
+#include "v1/protocol_binding/binder.h"
+
+namespace cloudevents {
+namespace binding {
+
+// Inheritence from template specialization to handle HttpMessages.
+// For the full template code and comments,
+// view `//v1/protocol_binding/binder.h`.
+//
+// Uses Boost beast's HTTP Request/ Response representation.
+//
+// User interacts with HttpReqBinder and HttpResBinder
+// which are both child classes of HttpBinder.
+
+template <bool IsReq>
+class HttpBinder: public Binder<
+  boost::beast::http::message<IsReq, boost::beast::http::string_body>> {
+ private:
+
+}  // namespace binding
+}  // namespace cloudevents
+
+#endif  // CLOUDEVENTSCPPSDK_V1_BINDING_HTTPBINDER_H

--- a/v1/protocol_binding/http_binder_test.cc
+++ b/v1/protocol_binding/http_binder_test.cc
@@ -1,0 +1,488 @@
+#include "http_binder.h"
+
+#include <gtest/gtest.h>
+
+namespace cloudevents {
+namespace binding {
+
+using ::absl::Status;
+using ::absl::OkStatus;
+using ::cloudevents_absl::StatusOr;
+using ::io::cloudevents::v1::CloudEvent;
+using ::cloudevents::format::Format;
+using ::boost::beast::http::message;
+using ::boost::beast::http::string_body;
+
+typedef io::cloudevents::v1::CloudEvent_CloudEventAttribute CeAttr;
+typedef boost::beast::http::request<string_body> HttpRequest;
+typedef boost::beast::http::response<string_body> HttpResponse;
+
+// Setup a valid CloudEvent
+class BindTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ce.set_id("1");
+    ce.set_source("2");
+    ce.set_spec_version("3");
+    ce.set_type("4");
+  }
+  CloudEvent ce;
+};
+
+// Setup a Binary Http Req containing valid CloudEvent
+class UnbindBinaryReqTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    http_req.base().set("ce-id", "1");
+    http_req.base().set("ce-source", "2");
+    http_req.base().set("ce-spec_version", "3");
+    http_req.base().set("ce-type", "4");
+  }
+  HttpReqBinder binder;
+  HttpRequest http_req;
+};
+
+// Setup a Structured Http Req containing valid CloudEvent
+class UnbindStructuredReqTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    http_req.base().set("content-type", "application/cloudevents+json");
+  }
+  std::string valid_payload = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
+  HttpReqBinder binder;
+  HttpRequest http_req;
+};
+
+// Setup a Binary Http Res containing valid CloudEvent
+class UnbindBinaryResTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    http_res.base().set("ce-id", "1");
+    http_res.base().set("ce-source", "2");
+    http_res.base().set("ce-spec_version", "3");
+    http_res.base().set("ce-type", "4");
+  }
+  HttpResBinder binder;
+  HttpResponse http_res;
+};
+
+// Setup a Structured Http Res containing valid CloudEvent
+class UnbindStructuredResTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    http_res.base().set("content-type", "application/cloudevents+json");
+  }
+  std::string valid_payload = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
+  HttpResBinder binder;
+  HttpResponse http_res;
+};
+
+
+// Tests not using the Fixture are named differently
+// as TEST and TEST_F cannot share the same test name.
+TEST(BindReqTest, Invalid) {
+  HttpReqBinder binder;
+  CloudEvent ce;
+  StatusOr<HttpRequest> bind = binder.Bind(ce);
+
+  ASSERT_FALSE(bind.ok());
+  ASSERT_TRUE(absl::IsInvalidArgument(bind.status()));
+}
+
+TEST_F(BindTest, BinaryReq_Required) {
+  HttpReqBinder binder;
+  StatusOr<HttpRequest> bind = binder.Bind(ce);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["ce-id"], "1");
+  ASSERT_EQ((*bind).base()["ce-source"], "2");
+  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-type"], "4");
+}
+
+TEST_F(BindTest, BinaryReq_Optional) {
+  CeAttr attr_val;
+  attr_val.set_ce_string("5");
+  (*ce.mutable_attributes())["opt"] = attr_val;
+  HttpReqBinder binder;
+  StatusOr<HttpRequest> bind = binder.Bind(ce);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["ce-id"], "1");
+  ASSERT_EQ((*bind).base()["ce-source"], "2");
+  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-type"], "4");
+}
+
+TEST_F(BindTest, BinaryReq_BinData) {
+  HttpReqBinder binder;
+  ce.set_binary_data("1010");
+
+  StatusOr<HttpRequest> bind = binder.Bind(ce);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["ce-id"], "1");
+  ASSERT_EQ((*bind).base()["ce-source"], "2");
+  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-type"], "4");
+  ASSERT_EQ((*bind).body(), "1010");
+}
+
+TEST_F(BindTest, BinaryReq_TextData) {
+  HttpReqBinder binder;
+  ce.set_text_data("hello");
+
+  StatusOr<HttpRequest> bind = binder.Bind(ce);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["ce-id"], "1");
+  ASSERT_EQ((*bind).base()["ce-source"], "2");
+  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-type"], "4");
+  ASSERT_EQ((*bind).body(), "hello");
+}
+
+TEST_F(BindTest, StructuredReq_Required) {
+  HttpReqBinder binder;
+
+  StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
+  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+}
+
+TEST_F(BindTest, StructuredReq_Optional) {
+  HttpReqBinder binder;
+  CeAttr attr_val;
+  attr_val.set_ce_string("5");
+  (*ce.mutable_attributes())["opt"] = attr_val;
+
+  StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
+  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"opt\" : \"5\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+}
+
+TEST_F(BindTest, StructuredReq_BinData) {
+  HttpReqBinder binder;
+  ce.set_binary_data("1010");
+
+  StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
+  ASSERT_EQ((*bind).body(), "{\n\t\"data_base64\" : \"1010\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+}
+
+TEST_F(BindTest, StructuredReq_TextData) {
+  HttpReqBinder binder;
+  ce.set_text_data("hello");
+
+  StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
+  ASSERT_EQ((*bind).body(), "{\n\t\"data\" : \"hello\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+}
+
+TEST_F(UnbindBinaryReqTest, Required) {
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "2");
+  ASSERT_EQ((*unbind).spec_version(), "3");
+  ASSERT_EQ((*unbind).type(), "4");
+}
+
+TEST_F(UnbindBinaryReqTest, Optional) {
+  http_req.base().set("ce-opt", "5");
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "2");
+  ASSERT_EQ((*unbind).spec_version(), "3");
+  ASSERT_EQ((*unbind).type(), "4");
+  ASSERT_EQ((*unbind).attributes().at("opt").ce_string(), "5");
+}
+
+TEST_F(UnbindBinaryReqTest, Data) {
+  http_req.body() = "hello";
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "2");
+  ASSERT_EQ((*unbind).spec_version(), "3");
+  ASSERT_EQ((*unbind).type(), "4");
+  ASSERT_EQ((*unbind).text_data(), "hello");
+}
+
+TEST_F(UnbindStructuredReqTest, Required) {
+  http_req.body() = valid_payload;
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "/test");
+  ASSERT_EQ((*unbind).spec_version(), "1.0");
+  ASSERT_EQ((*unbind).type(), "test");
+}
+
+TEST_F(UnbindStructuredReqTest, Optional) {
+  std::string payload = valid_payload;
+  payload.insert(1, "\t\"opt\" : \"5\",\n");
+  http_req.body() = payload;
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "/test");
+  ASSERT_EQ((*unbind).spec_version(), "1.0");
+  ASSERT_EQ((*unbind).type(), "test");
+  ASSERT_EQ((*unbind).attributes().at("opt").ce_string(), "5");
+}
+
+TEST_F(UnbindStructuredReqTest, BinData) {
+  std::string payload = valid_payload;
+  payload.insert(1, "\t\"data_base64\" : \"1010\",\n");
+  http_req.body() = payload;
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "/test");
+  ASSERT_EQ((*unbind).spec_version(), "1.0");
+  ASSERT_EQ((*unbind).type(), "test");
+  ASSERT_EQ((*unbind).binary_data(), "1010");
+}
+
+TEST_F(UnbindStructuredReqTest, TextData) {
+  std::string payload = valid_payload;
+  payload.insert(1, "\t\"data\" : \"hello\",\n");
+  http_req.body() = payload;
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "/test");
+  ASSERT_EQ((*unbind).spec_version(), "1.0");
+  ASSERT_EQ((*unbind).type(), "test");
+  ASSERT_EQ((*unbind).text_data(), "hello");
+}
+
+TEST(BindResTest, Invalid) {
+  HttpResBinder binder;
+  CloudEvent ce;
+  StatusOr<HttpResponse> bind = binder.Bind(ce);
+
+  ASSERT_FALSE(bind.ok());
+  ASSERT_TRUE(absl::IsInvalidArgument(bind.status()));
+}
+
+TEST_F(BindTest, BinaryRes_Required) {
+  HttpResBinder binder;
+
+  StatusOr<HttpResponse> bind = binder.Bind(ce);
+
+  std::cerr << bind.status();
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["ce-id"], "1");
+  ASSERT_EQ((*bind).base()["ce-source"], "2");
+  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-type"], "4");
+}
+
+TEST_F(BindTest, BinaryRes_Optional) {
+  HttpResBinder binder;
+  CeAttr attr_val;
+  attr_val.set_ce_string("5");
+  (*ce.mutable_attributes())["opt"] = attr_val;
+
+  StatusOr<HttpResponse> bind = binder.Bind(ce);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["ce-id"], "1");
+  ASSERT_EQ((*bind).base()["ce-source"], "2");
+  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-type"], "4");
+  ASSERT_EQ((*bind).base()["ce-opt"], "5");
+}
+
+TEST_F(BindTest, BinaryRes_BinData) {
+  HttpResBinder binder;
+  ce.set_binary_data("1010");
+
+  StatusOr<HttpResponse> bind = binder.Bind(ce);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["ce-id"], "1");
+  ASSERT_EQ((*bind).base()["ce-source"], "2");
+  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-type"], "4");
+  ASSERT_EQ((*bind).body(), "1010");
+}
+
+TEST_F(BindTest, BinaryRes_TextData) {
+  HttpResBinder binder;
+  ce.set_text_data("hello");
+
+  StatusOr<HttpResponse> bind = binder.Bind(ce);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["ce-id"], "1");
+  ASSERT_EQ((*bind).base()["ce-source"], "2");
+  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-type"], "4");
+  ASSERT_EQ((*bind).body(), "hello");
+}
+
+TEST_F(BindTest, StructuredRes_Required) {
+  HttpResBinder binder;
+
+  StatusOr<HttpResponse> bind = binder.Bind(ce, Format::kJson);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
+  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+}
+
+TEST_F(BindTest, StructuredRes_Optional) {
+  HttpResBinder binder;
+  CeAttr attr_val;
+  attr_val.set_ce_string("5");
+  (*ce.mutable_attributes())["opt"] = attr_val;
+
+  StatusOr<HttpResponse> bind = binder.Bind(ce, Format::kJson);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
+  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"opt\" : \"5\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+}
+
+TEST_F(BindTest, StructuredRes_BinData) {
+  HttpResBinder binder;
+  ce.set_binary_data("1010");
+
+  StatusOr<HttpResponse> bind = binder.Bind(ce, Format::kJson);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
+  ASSERT_EQ((*bind).body(), "{\n\t\"data_base64\" : \"1010\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+}
+
+TEST_F(BindTest, StructuredRes_TextData) {
+  HttpResBinder binder;
+  ce.set_text_data("hello");
+
+  StatusOr<HttpResponse> bind = binder.Bind(ce, Format::kJson);
+
+  ASSERT_TRUE(bind.ok());
+  ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
+  ASSERT_EQ((*bind).body(), "{\n\t\"data\" : \"hello\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+}
+
+TEST_F(UnbindBinaryResTest, Required) {
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "2");
+  ASSERT_EQ((*unbind).spec_version(), "3");
+  ASSERT_EQ((*unbind).type(), "4");
+}
+
+TEST_F(UnbindBinaryResTest, Optional) {
+  http_res.base().set("ce-opt", "5");
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "2");
+  ASSERT_EQ((*unbind).spec_version(), "3");
+  ASSERT_EQ((*unbind).type(), "4");
+  ASSERT_EQ((*unbind).attributes().at("opt").ce_string(), "5");
+}
+
+TEST_F(UnbindBinaryResTest, Data) {
+  http_res.body() = "hello";
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "2");
+  ASSERT_EQ((*unbind).spec_version(), "3");
+  ASSERT_EQ((*unbind).type(), "4");
+  ASSERT_EQ((*unbind).text_data(), "hello");
+}
+
+TEST_F(UnbindStructuredResTest, Required) {
+  http_res.body() = valid_payload;
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "/test");
+  ASSERT_EQ((*unbind).spec_version(), "1.0");
+  ASSERT_EQ((*unbind).type(), "test");
+}
+
+TEST_F(UnbindStructuredResTest, Optional) {
+  std::string payload = valid_payload;
+  payload.insert(1, "\t\"opt\" : \"5\",\n");
+  http_res.body() = payload;
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "/test");
+  ASSERT_EQ((*unbind).spec_version(), "1.0");
+  ASSERT_EQ((*unbind).type(), "test");
+  ASSERT_EQ((*unbind).attributes().at("opt").ce_string(), "5");
+}
+
+TEST_F(UnbindStructuredResTest, BinData) {
+  std::string payload = valid_payload;
+  payload.insert(1, "\t\"data_base64\" : \"1010\",\n");
+  http_res.body() = payload;
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "/test");
+  ASSERT_EQ((*unbind).spec_version(), "1.0");
+  ASSERT_EQ((*unbind).type(), "test");
+  ASSERT_EQ((*unbind).binary_data(), "1010");
+}
+
+TEST_F(UnbindStructuredResTest, TetData) {
+  std::string payload = valid_payload;
+  payload.insert(1, "\t\"data\" : \"hello\",\n");
+  http_res.body() = payload;
+
+  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+
+  ASSERT_TRUE(unbind.ok());
+  ASSERT_EQ((*unbind).id(), "1");
+  ASSERT_EQ((*unbind).source(), "/test");
+  ASSERT_EQ((*unbind).spec_version(), "1.0");
+  ASSERT_EQ((*unbind).type(), "test");
+  ASSERT_EQ((*unbind).text_data(), "hello");
+}
+
+}  // namespace binding
+}  // namespace cloudevents

--- a/v1/protocol_binding/http_binder_test.cc
+++ b/v1/protocol_binding/http_binder_test.cc
@@ -5,9 +5,6 @@
 namespace cloudevents {
 namespace binding {
 
-using ::absl::Status;
-using ::absl::OkStatus;
-using ::cloudevents_absl::StatusOr;
 using ::io::cloudevents::v1::CloudEvent;
 using ::cloudevents::format::Format;
 using ::boost::beast::http::message;
@@ -83,7 +80,7 @@ class UnbindStructuredResTest : public ::testing::Test {
 TEST(BindReqTest, Invalid) {
   HttpReqBinder binder;
   CloudEvent ce;
-  StatusOr<HttpRequest> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce);
 
   ASSERT_FALSE(bind.ok());
   ASSERT_TRUE(absl::IsInvalidArgument(bind.status()));
@@ -91,7 +88,7 @@ TEST(BindReqTest, Invalid) {
 
 TEST_F(BindTest, BinaryReq_Required) {
   HttpReqBinder binder;
-  StatusOr<HttpRequest> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
@@ -105,7 +102,7 @@ TEST_F(BindTest, BinaryReq_Optional) {
   attr_val.set_ce_string("5");
   (*ce.mutable_attributes())["opt"] = attr_val;
   HttpReqBinder binder;
-  StatusOr<HttpRequest> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
@@ -118,7 +115,7 @@ TEST_F(BindTest, BinaryReq_BinData) {
   HttpReqBinder binder;
   ce.set_binary_data("1010");
 
-  StatusOr<HttpRequest> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
@@ -132,7 +129,7 @@ TEST_F(BindTest, BinaryReq_TextData) {
   HttpReqBinder binder;
   ce.set_text_data("hello");
 
-  StatusOr<HttpRequest> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
@@ -145,7 +142,7 @@ TEST_F(BindTest, BinaryReq_TextData) {
 TEST_F(BindTest, StructuredReq_Required) {
   HttpReqBinder binder;
 
-  StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
@@ -158,7 +155,8 @@ TEST_F(BindTest, StructuredReq_Optional) {
   attr_val.set_ce_string("5");
   (*ce.mutable_attributes())["opt"] = attr_val;
 
-  StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce,
+    Format::kJson);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
@@ -169,7 +167,8 @@ TEST_F(BindTest, StructuredReq_BinData) {
   HttpReqBinder binder;
   ce.set_binary_data("1010");
 
-  StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce,
+    Format::kJson);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
@@ -180,7 +179,8 @@ TEST_F(BindTest, StructuredReq_TextData) {
   HttpReqBinder binder;
   ce.set_text_data("hello");
 
-  StatusOr<HttpRequest> bind = binder.Bind(ce, Format::kJson);
+  cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce,
+    Format::kJson);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
@@ -188,7 +188,7 @@ TEST_F(BindTest, StructuredReq_TextData) {
 }
 
 TEST_F(UnbindBinaryReqTest, Required) {
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -200,7 +200,7 @@ TEST_F(UnbindBinaryReqTest, Required) {
 TEST_F(UnbindBinaryReqTest, Optional) {
   http_req.base().set("ce-opt", "5");
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -213,7 +213,7 @@ TEST_F(UnbindBinaryReqTest, Optional) {
 TEST_F(UnbindBinaryReqTest, Data) {
   http_req.body() = "1010";
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -226,7 +226,7 @@ TEST_F(UnbindBinaryReqTest, Data) {
 TEST_F(UnbindStructuredReqTest, Required) {
   http_req.body() = valid_payload;
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -240,7 +240,7 @@ TEST_F(UnbindStructuredReqTest, Optional) {
   payload.insert(1, "\t\"opt\" : \"5\",\n");
   http_req.body() = payload;
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -255,7 +255,7 @@ TEST_F(UnbindStructuredReqTest, BinData) {
   payload.insert(1, "\t\"data_base64\" : \"1010\",\n");
   http_req.body() = payload;
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -270,7 +270,7 @@ TEST_F(UnbindStructuredReqTest, TextData) {
   payload.insert(1, "\t\"data\" : \"hello\",\n");
   http_req.body() = payload;
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -283,7 +283,7 @@ TEST_F(UnbindStructuredReqTest, TextData) {
 TEST(BindResTest, Invalid) {
   HttpResBinder binder;
   CloudEvent ce;
-  StatusOr<HttpResponse> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce);
 
   ASSERT_FALSE(bind.ok());
   ASSERT_TRUE(absl::IsInvalidArgument(bind.status()));
@@ -292,7 +292,7 @@ TEST(BindResTest, Invalid) {
 TEST_F(BindTest, BinaryRes_Required) {
   HttpResBinder binder;
 
-  StatusOr<HttpResponse> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce);
 
   std::cerr << bind.status();
   ASSERT_TRUE(bind.ok());
@@ -308,7 +308,7 @@ TEST_F(BindTest, BinaryRes_Optional) {
   attr_val.set_ce_string("5");
   (*ce.mutable_attributes())["opt"] = attr_val;
 
-  StatusOr<HttpResponse> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
@@ -322,7 +322,7 @@ TEST_F(BindTest, BinaryRes_BinData) {
   HttpResBinder binder;
   ce.set_binary_data("1010");
 
-  StatusOr<HttpResponse> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
@@ -336,7 +336,7 @@ TEST_F(BindTest, BinaryRes_TextData) {
   HttpResBinder binder;
   ce.set_text_data("hello");
 
-  StatusOr<HttpResponse> bind = binder.Bind(ce);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
@@ -349,7 +349,8 @@ TEST_F(BindTest, BinaryRes_TextData) {
 TEST_F(BindTest, StructuredRes_Required) {
   HttpResBinder binder;
 
-  StatusOr<HttpResponse> bind = binder.Bind(ce, Format::kJson);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce,
+    Format::kJson);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
@@ -362,7 +363,8 @@ TEST_F(BindTest, StructuredRes_Optional) {
   attr_val.set_ce_string("5");
   (*ce.mutable_attributes())["opt"] = attr_val;
 
-  StatusOr<HttpResponse> bind = binder.Bind(ce, Format::kJson);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce,
+    Format::kJson);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
@@ -373,7 +375,8 @@ TEST_F(BindTest, StructuredRes_BinData) {
   HttpResBinder binder;
   ce.set_binary_data("1010");
 
-  StatusOr<HttpResponse> bind = binder.Bind(ce, Format::kJson);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce,
+    Format::kJson);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
@@ -384,7 +387,8 @@ TEST_F(BindTest, StructuredRes_TextData) {
   HttpResBinder binder;
   ce.set_text_data("hello");
 
-  StatusOr<HttpResponse> bind = binder.Bind(ce, Format::kJson);
+  cloudevents_absl::StatusOr<HttpResponse> bind = binder.Bind(ce,
+    Format::kJson);
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
@@ -392,7 +396,7 @@ TEST_F(BindTest, StructuredRes_TextData) {
 }
 
 TEST_F(UnbindBinaryResTest, Required) {
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -404,7 +408,7 @@ TEST_F(UnbindBinaryResTest, Required) {
 TEST_F(UnbindBinaryResTest, Optional) {
   http_res.base().set("ce-opt", "5");
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -417,7 +421,7 @@ TEST_F(UnbindBinaryResTest, Optional) {
 TEST_F(UnbindBinaryResTest, Data) {
   http_res.body() = "1010";
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -430,7 +434,7 @@ TEST_F(UnbindBinaryResTest, Data) {
 TEST_F(UnbindStructuredResTest, Required) {
   http_res.body() = valid_payload;
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -444,7 +448,7 @@ TEST_F(UnbindStructuredResTest, Optional) {
   payload.insert(1, "\t\"opt\" : \"5\",\n");
   http_res.body() = payload;
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -459,7 +463,7 @@ TEST_F(UnbindStructuredResTest, BinData) {
   payload.insert(1, "\t\"data_base64\" : \"1010\",\n");
   http_res.body() = payload;
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");
@@ -474,7 +478,7 @@ TEST_F(UnbindStructuredResTest, TetData) {
   payload.insert(1, "\t\"data\" : \"hello\",\n");
   http_res.body() = payload;
 
-  StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
+  cloudevents_absl::StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
 
   ASSERT_TRUE(unbind.ok());
   ASSERT_EQ((*unbind).id(), "1");

--- a/v1/protocol_binding/http_binder_test.cc
+++ b/v1/protocol_binding/http_binder_test.cc
@@ -35,7 +35,7 @@ class UnbindBinaryReqTest : public ::testing::Test {
   void SetUp() override {
     http_req.base().set("ce-id", "1");
     http_req.base().set("ce-source", "2");
-    http_req.base().set("ce-spec_version", "3");
+    http_req.base().set("ce-specversion", "3");
     http_req.base().set("ce-type", "4");
   }
   HttpReqBinder binder;
@@ -48,7 +48,7 @@ class UnbindStructuredReqTest : public ::testing::Test {
   void SetUp() override {
     http_req.base().set("content-type", "application/cloudevents+json");
   }
-  std::string valid_payload = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
+  std::string valid_payload = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"specversion\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
   HttpReqBinder binder;
   HttpRequest http_req;
 };
@@ -59,7 +59,7 @@ class UnbindBinaryResTest : public ::testing::Test {
   void SetUp() override {
     http_res.base().set("ce-id", "1");
     http_res.base().set("ce-source", "2");
-    http_res.base().set("ce-spec_version", "3");
+    http_res.base().set("ce-specversion", "3");
     http_res.base().set("ce-type", "4");
   }
   HttpResBinder binder;
@@ -72,7 +72,7 @@ class UnbindStructuredResTest : public ::testing::Test {
   void SetUp() override {
     http_res.base().set("content-type", "application/cloudevents+json");
   }
-  std::string valid_payload = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
+  std::string valid_payload = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"specversion\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
   HttpResBinder binder;
   HttpResponse http_res;
 };
@@ -96,7 +96,7 @@ TEST_F(BindTest, BinaryReq_Required) {
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
   ASSERT_EQ((*bind).base()["ce-source"], "2");
-  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
 }
 
@@ -110,7 +110,7 @@ TEST_F(BindTest, BinaryReq_Optional) {
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
   ASSERT_EQ((*bind).base()["ce-source"], "2");
-  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
 }
 
@@ -123,7 +123,7 @@ TEST_F(BindTest, BinaryReq_BinData) {
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
   ASSERT_EQ((*bind).base()["ce-source"], "2");
-  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
   ASSERT_EQ((*bind).body(), "1010");
 }
@@ -137,7 +137,7 @@ TEST_F(BindTest, BinaryReq_TextData) {
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
   ASSERT_EQ((*bind).base()["ce-source"], "2");
-  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
   ASSERT_EQ((*bind).body(), "hello");
 }
@@ -149,7 +149,7 @@ TEST_F(BindTest, StructuredReq_Required) {
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
-  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"specversion\" : \"3\",\n\t\"type\" : \"4\"\n}");
 }
 
 TEST_F(BindTest, StructuredReq_Optional) {
@@ -162,7 +162,7 @@ TEST_F(BindTest, StructuredReq_Optional) {
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
-  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"opt\" : \"5\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"opt\" : \"5\",\n\t\"source\" : \"2\",\n\t\"specversion\" : \"3\",\n\t\"type\" : \"4\"\n}");
 }
 
 TEST_F(BindTest, StructuredReq_BinData) {
@@ -173,7 +173,7 @@ TEST_F(BindTest, StructuredReq_BinData) {
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
-  ASSERT_EQ((*bind).body(), "{\n\t\"data_base64\" : \"1010\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+  ASSERT_EQ((*bind).body(), "{\n\t\"data_base64\" : \"1010\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"specversion\" : \"3\",\n\t\"type\" : \"4\"\n}");
 }
 
 TEST_F(BindTest, StructuredReq_TextData) {
@@ -184,7 +184,7 @@ TEST_F(BindTest, StructuredReq_TextData) {
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
-  ASSERT_EQ((*bind).body(), "{\n\t\"data\" : \"hello\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+  ASSERT_EQ((*bind).body(), "{\n\t\"data\" : \"hello\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"specversion\" : \"3\",\n\t\"type\" : \"4\"\n}");
 }
 
 TEST_F(UnbindBinaryReqTest, Required) {
@@ -298,7 +298,7 @@ TEST_F(BindTest, BinaryRes_Required) {
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
   ASSERT_EQ((*bind).base()["ce-source"], "2");
-  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
 }
 
@@ -313,7 +313,7 @@ TEST_F(BindTest, BinaryRes_Optional) {
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
   ASSERT_EQ((*bind).base()["ce-source"], "2");
-  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
   ASSERT_EQ((*bind).base()["ce-opt"], "5");
 }
@@ -327,7 +327,7 @@ TEST_F(BindTest, BinaryRes_BinData) {
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
   ASSERT_EQ((*bind).base()["ce-source"], "2");
-  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
   ASSERT_EQ((*bind).body(), "1010");
 }
@@ -341,7 +341,7 @@ TEST_F(BindTest, BinaryRes_TextData) {
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["ce-id"], "1");
   ASSERT_EQ((*bind).base()["ce-source"], "2");
-  ASSERT_EQ((*bind).base()["ce-spec_version"], "3");
+  ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
   ASSERT_EQ((*bind).body(), "hello");
 }
@@ -353,7 +353,7 @@ TEST_F(BindTest, StructuredRes_Required) {
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
-  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"specversion\" : \"3\",\n\t\"type\" : \"4\"\n}");
 }
 
 TEST_F(BindTest, StructuredRes_Optional) {
@@ -366,7 +366,7 @@ TEST_F(BindTest, StructuredRes_Optional) {
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
-  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"opt\" : \"5\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+  ASSERT_EQ((*bind).body(), "{\n\t\"id\" : \"1\",\n\t\"opt\" : \"5\",\n\t\"source\" : \"2\",\n\t\"specversion\" : \"3\",\n\t\"type\" : \"4\"\n}");
 }
 
 TEST_F(BindTest, StructuredRes_BinData) {
@@ -377,7 +377,7 @@ TEST_F(BindTest, StructuredRes_BinData) {
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
-  ASSERT_EQ((*bind).body(), "{\n\t\"data_base64\" : \"1010\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+  ASSERT_EQ((*bind).body(), "{\n\t\"data_base64\" : \"1010\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"specversion\" : \"3\",\n\t\"type\" : \"4\"\n}");
 }
 
 TEST_F(BindTest, StructuredRes_TextData) {
@@ -388,7 +388,7 @@ TEST_F(BindTest, StructuredRes_TextData) {
 
   ASSERT_TRUE(bind.ok());
   ASSERT_EQ((*bind).base()["content-type"], "application/cloudevents+json");
-  ASSERT_EQ((*bind).body(), "{\n\t\"data\" : \"hello\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"spec_version\" : \"3\",\n\t\"type\" : \"4\"\n}");
+  ASSERT_EQ((*bind).body(), "{\n\t\"data\" : \"hello\",\n\t\"id\" : \"1\",\n\t\"source\" : \"2\",\n\t\"specversion\" : \"3\",\n\t\"type\" : \"4\"\n}");
 }
 
 TEST_F(UnbindBinaryResTest, Required) {

--- a/v1/protocol_binding/http_binder_test.cc
+++ b/v1/protocol_binding/http_binder_test.cc
@@ -114,6 +114,10 @@ TEST_F(BindTest, BinaryReq_Optional) {
 TEST_F(BindTest, BinaryReq_BinData) {
   HttpReqBinder binder;
   ce.set_binary_data("1010");
+  std::string content_type_str = "text/plain";
+  CeAttr content_type;
+  content_type.set_ce_string(content_type_str);
+  (*ce.mutable_attributes())["datacontenttype"] = content_type;
 
   cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce);
 
@@ -122,12 +126,17 @@ TEST_F(BindTest, BinaryReq_BinData) {
   ASSERT_EQ((*bind).base()["ce-source"], "2");
   ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
+  ASSERT_EQ((*bind).base()["content-type"], content_type_str);
   ASSERT_EQ((*bind).body(), "1010");
 }
 
 TEST_F(BindTest, BinaryReq_TextData) {
   HttpReqBinder binder;
   ce.set_text_data("hello");
+  std::string content_type_str = "text/plain";
+  CeAttr content_type;
+  content_type.set_ce_string(content_type_str);
+  (*ce.mutable_attributes())["datacontenttype"] = content_type;
 
   cloudevents_absl::StatusOr<HttpRequest> bind = binder.Bind(ce);
 
@@ -136,6 +145,7 @@ TEST_F(BindTest, BinaryReq_TextData) {
   ASSERT_EQ((*bind).base()["ce-source"], "2");
   ASSERT_EQ((*bind).base()["ce-specversion"], "3");
   ASSERT_EQ((*bind).base()["ce-type"], "4");
+  ASSERT_EQ((*bind).base()["content-type"], content_type_str);
   ASSERT_EQ((*bind).body(), "hello");
 }
 

--- a/v1/protocol_binding/http_binder_test.cc
+++ b/v1/protocol_binding/http_binder_test.cc
@@ -211,7 +211,7 @@ TEST_F(UnbindBinaryReqTest, Optional) {
 }
 
 TEST_F(UnbindBinaryReqTest, Data) {
-  http_req.body() = "hello";
+  http_req.body() = "1010";
 
   StatusOr<CloudEvent> unbind = binder.Unbind(http_req);
 
@@ -220,7 +220,7 @@ TEST_F(UnbindBinaryReqTest, Data) {
   ASSERT_EQ((*unbind).source(), "2");
   ASSERT_EQ((*unbind).spec_version(), "3");
   ASSERT_EQ((*unbind).type(), "4");
-  ASSERT_EQ((*unbind).text_data(), "hello");
+  ASSERT_EQ((*unbind).binary_data(), "1010");
 }
 
 TEST_F(UnbindStructuredReqTest, Required) {
@@ -415,7 +415,7 @@ TEST_F(UnbindBinaryResTest, Optional) {
 }
 
 TEST_F(UnbindBinaryResTest, Data) {
-  http_res.body() = "hello";
+  http_res.body() = "1010";
 
   StatusOr<CloudEvent> unbind = binder.Unbind(http_res);
 
@@ -424,7 +424,7 @@ TEST_F(UnbindBinaryResTest, Data) {
   ASSERT_EQ((*unbind).source(), "2");
   ASSERT_EQ((*unbind).spec_version(), "3");
   ASSERT_EQ((*unbind).type(), "4");
-  ASSERT_EQ((*unbind).text_data(), "hello");
+  ASSERT_EQ((*unbind).binary_data(), "1010");
 }
 
 TEST_F(UnbindStructuredResTest, Required) {


### PR DESCRIPTION
- template class HttpBinder<bool IsReq> inherits from template specialization of Binder
- implements Binder virtual funcs
- HttpReqBinder and HttpResBinder inherits from HttpBinder specialized to IsReq=true and isReq=false (matching boost beast representation)

- [x] Tests pass
- [x] Appropriate changes to README are included in PR - User instructions in binder-pubsub branch 