### PR TITLE
[Stage 1] Namespace third party

### DIFF
--- a/third_party/base64/base64.cc
+++ b/third_party/base64/base64.cc
@@ -23,7 +23,7 @@
 
 #include "base64.h"
 
-namespace base64 {
+namespace cloudevents_base64 {
 
  //
  // Depending on the url parameter in base64_chars, one of
@@ -247,4 +247,4 @@ std::string base64_decode(std::string_view s, bool remove_linebreaks) {
 
 #endif  // __cplusplus >= 201703L
 
-}  // namespace base64
+}  // namespace cloudevents_base64

--- a/third_party/base64/base64.h
+++ b/third_party/base64/base64.h
@@ -12,7 +12,7 @@
 #include <string_view>
 #endif  // __cplusplus >= 201703L
 
-namespace base64 {
+namespace cloudevents_base64 {
     
 std::string base64_encode     (std::string const& s, bool url = false);
 std::string base64_encode_pem (std::string const& s);
@@ -34,7 +34,7 @@ std::string base64_encode_mime(std::string_view s);
 std::string base64_decode(std::string_view s, bool remove_linebreaks = false);
 #endif  // __cplusplus >= 201703L
 
-}  // namespace base64
+}  // namespace cloudevents_base64
 
 #endif  /* BASE64_H_C0CE2A47_D10E_42C9_A27C_C883944E704A */
 

--- a/third_party/base64/base64_test.cc
+++ b/third_party/base64/base64_test.cc
@@ -3,8 +3,7 @@
 
 #include <gtest/gtest.h>
 
-namespace base64 {
-
+namespace cloudevents_base64 {
 
 // Test all possibilites of fill bytes (none, one =, two ==)
 // References calculated with: https://www.base64encode.org/
@@ -76,5 +75,4 @@ TEST(Decode, FillTwo) {
    ASSERT_EQ(rest2_decoded, rest2_original);
 }
 
-
-}  // namespace base64
+}  // namespace cloudevents_base64

--- a/third_party/base64/os.h
+++ b/third_party/base64/os.h
@@ -12,6 +12,8 @@
 #include <cstddef>
 #include <cstdlib>
 
+namespace cloudevents_base64 {
+    
 typedef long os_time_t;
 
 /**
@@ -509,6 +511,7 @@ static inline void * os_realloc_array(void *ptr, size_t nmemb, size_t size)
  */
 size_t os_strlcpy(char *dest, const char *src, size_t siz);
 
+}  // namespace cloudevents_base64
 
 #ifdef OS_REJECT_C_LIB_FUNCTIONS
 #define malloc OS_DO_NOT_USE_malloc

--- a/third_party/statusor/statusor.cc
+++ b/third_party/statusor/statusor.cc
@@ -25,8 +25,7 @@
 
 //#include "common/common/assert.h"
 
-namespace absl {
-
+namespace cloudevents_absl {
 namespace internal_statusor {
 
 void Helper::HandleInvalidStatusCtorArg(absl::Status* status) {
@@ -38,6 +37,5 @@ void Helper::HandleInvalidStatusCtorArg(absl::Status* status) {
 
 void Helper::Crash(const absl::Status&) { abort(); }
 
-} // namespace internal_statusor
-
-} // namespace absl
+}  // namespace internal_statusor
+}  // namespace cloudevents_absl

--- a/third_party/statusor/statusor.h
+++ b/third_party/statusor/statusor.h
@@ -78,7 +78,7 @@
 #include "absl/base/attributes.h"
 #include "absl/base/macros.h"
 
-namespace absl {
+namespace cloudevents_absl {
 
 // Returned StatusOr objects may not be ignored.
 template <typename T> class ABSL_MUST_USE_RESULT StatusOr;
@@ -352,6 +352,6 @@ template <typename T> void StatusOr<T>::IgnoreError() const {
   // no-op
 }
 
-} // namespace absl
+}  // namespace absl
 
 #endif

--- a/third_party/statusor/statusor_internals.h
+++ b/third_party/statusor/statusor_internals.h
@@ -30,7 +30,7 @@
 #include "absl/meta/type_traits.h"
 #include "absl/status/status.h"
 
-namespace absl {
+namespace cloudevents_absl {
 
 namespace internal_statusor {
 
@@ -244,6 +244,6 @@ template <> struct TraitsBase<false, false> {
 
 } // namespace internal_statusor
 
-} // namespace absl
+} // namespace cloudevents_absl
 
 #endif

--- a/third_party/statusor/statusor_test.cc
+++ b/third_party/statusor/statusor_test.cc
@@ -25,7 +25,7 @@ limitations under the License.
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace absl {
+namespace cloudevents_absl {
 namespace {
 
 
@@ -150,8 +150,8 @@ TEST(StatusOr, TestMoveWithValuesAndErrors) {
   StatusOr<std::string> status_or(std::string(1000, '0'));
   StatusOr<std::string> value1(std::string(1000, '1'));
   StatusOr<std::string> value2(std::string(1000, '2'));
-  StatusOr<std::string> error1(Status(absl::StatusCode::kUnknown, "error1"));
-  StatusOr<std::string> error2(Status(absl::StatusCode::kUnknown, "error2"));
+  StatusOr<std::string> error1(absl::Status(absl::StatusCode::kUnknown, "error1"));
+  StatusOr<std::string> error2(absl::Status(absl::StatusCode::kUnknown, "error2"));
 
   ASSERT_TRUE(status_or.ok());
   EXPECT_EQ(std::string(1000, '0'), status_or.value());
@@ -181,8 +181,8 @@ TEST(StatusOr, TestCopyWithValuesAndErrors) {
   StatusOr<std::string> status_or(std::string(1000, '0'));
   StatusOr<std::string> value1(std::string(1000, '1'));
   StatusOr<std::string> value2(std::string(1000, '2'));
-  StatusOr<std::string> error1(Status(absl::StatusCode::kUnknown, "error1"));
-  StatusOr<std::string> error2(Status(absl::StatusCode::kUnknown, "error2"));
+  StatusOr<std::string> error1(absl::Status(absl::StatusCode::kUnknown, "error1"));
+  StatusOr<std::string> error2(absl::Status(absl::StatusCode::kUnknown, "error2"));
 
   ASSERT_TRUE(status_or.ok());
   EXPECT_EQ(std::string(1000, '0'), status_or.value());
@@ -229,7 +229,7 @@ TEST(StatusOrDeathTest, TestDefaultCtorValue) {
 }
 
 TEST(StatusOr, TestStatusCtor) {
-  StatusOr<int> thing(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<int> thing(absl::Status(absl::StatusCode::kCancelled, ""));
   EXPECT_FALSE(thing.ok());
   EXPECT_EQ(thing.status().code(), absl::StatusCode::kCancelled);
 }
@@ -250,7 +250,7 @@ TEST(StatusOr, TestCopyCtorStatusOk) {
 }
 
 TEST(StatusOr, TestCopyCtorStatusNotOk) {
-  StatusOr<int> original(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<int> original(absl::Status(absl::StatusCode::kCancelled, ""));
   StatusOr<int> copy(original);
   EXPECT_EQ(copy.status(), original.status());
 }
@@ -273,7 +273,7 @@ TEST(StatusOr, TestCopyCtorStatusOKConverting) {
 }
 
 TEST(StatusOr, TestCopyCtorStatusNotOkConverting) {
-  StatusOr<int> original(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<int> original(absl::Status(absl::StatusCode::kCancelled, ""));
   StatusOr<double> copy(original);
   EXPECT_EQ(copy.status(), original.status());
 }
@@ -288,7 +288,7 @@ TEST(StatusOr, TestAssignmentStatusOk) {
 }
 
 TEST(StatusOr, TestAssignmentStatusNotOk) {
-  StatusOr<int> source(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<int> source(absl::Status(absl::StatusCode::kCancelled, ""));
   StatusOr<int> target;
   target = source;
   EXPECT_EQ(target.status(), source.status());
@@ -297,9 +297,9 @@ TEST(StatusOr, TestAssignmentStatusNotOk) {
 TEST(StatusOr, TestStatus) {
   StatusOr<int> good(4);
   EXPECT_TRUE(good.ok());
-  StatusOr<int> bad(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<int> bad(absl::Status(absl::StatusCode::kCancelled, ""));
   EXPECT_FALSE(bad.ok());
-  EXPECT_EQ(bad.status(), Status(absl::StatusCode::kCancelled, ""));
+  EXPECT_EQ(bad.status(), absl::Status(absl::StatusCode::kCancelled, ""));
 }
 
 TEST(StatusOr, TestValue) {
@@ -315,12 +315,12 @@ TEST(StatusOr, TestValueConst) {
 }
 
 TEST(StatusOrDeathTest, TestValueNotOk) {
-  StatusOr<int> thing(Status(absl::StatusCode::kCancelled, "cancelled"));
+  StatusOr<int> thing(absl::Status(absl::StatusCode::kCancelled, "cancelled"));
   EXPECT_DEATH(thing.value(), "");
 }
 
 TEST(StatusOrDeathTest, TestValueNotOkConst) {
-  const StatusOr<int> thing(Status(absl::StatusCode::kUnknown, ""));
+  const StatusOr<int> thing(absl::Status(absl::StatusCode::kUnknown, ""));
   EXPECT_DEATH(thing.value(), "");
 }
 
@@ -336,9 +336,9 @@ TEST(StatusOrDeathTest, TestPointerDefaultCtorValue) {
 }
 
 TEST(StatusOr, TestPointerStatusCtor) {
-  StatusOr<int*> thing(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<int*> thing(absl::Status(absl::StatusCode::kCancelled, ""));
   EXPECT_FALSE(thing.ok());
-  EXPECT_EQ(thing.status(), Status(absl::StatusCode::kCancelled, ""));
+  EXPECT_EQ(thing.status(), absl::Status(absl::StatusCode::kCancelled, ""));
 }
 
 TEST(StatusOr, TestPointerValueCtor) {
@@ -357,7 +357,7 @@ TEST(StatusOr, TestPointerCopyCtorStatusOk) {
 }
 
 TEST(StatusOr, TestPointerCopyCtorStatusNotOk) {
-  StatusOr<int*> original(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<int*> original(absl::Status(absl::StatusCode::kCancelled, ""));
   StatusOr<int*> copy(original);
   EXPECT_EQ(copy.status(), original.status());
 }
@@ -372,7 +372,7 @@ TEST(StatusOr, TestPointerCopyCtorStatusOKConverting) {
 }
 
 TEST(StatusOr, TestPointerCopyCtorStatusNotOkConverting) {
-  StatusOr<Derived*> original(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<Derived*> original(absl::Status(absl::StatusCode::kCancelled, ""));
   StatusOr<Base2*> copy(original);
   EXPECT_EQ(copy.status(), original.status());
 }
@@ -387,7 +387,7 @@ TEST(StatusOr, TestPointerAssignmentStatusOk) {
 }
 
 TEST(StatusOr, TestPointerAssignmentStatusNotOk) {
-  StatusOr<int*> source(Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<int*> source(absl::Status(absl::StatusCode::kCancelled, ""));
   StatusOr<int*> target;
   target = source;
   EXPECT_EQ(target.status(), source.status());
@@ -397,8 +397,8 @@ TEST(StatusOr, TestPointerStatus) {
   const int kI = 0;
   StatusOr<const int*> good(&kI);
   EXPECT_TRUE(good.ok());
-  StatusOr<const int*> bad(Status(absl::StatusCode::kCancelled, ""));
-  EXPECT_EQ(bad.status(), Status(absl::StatusCode::kCancelled, ""));
+  StatusOr<const int*> bad(absl::Status(absl::StatusCode::kCancelled, ""));
+  EXPECT_EQ(bad.status(), absl::Status(absl::StatusCode::kCancelled, ""));
 }
 
 TEST(StatusOr, TestPointerValue) {
@@ -423,16 +423,16 @@ TEST(StatusOr, TestPointerValueConst) {
 // }
 
 TEST(StatusOrDeathTest, TestPointerValueNotOk) {
-  StatusOr<int*> thing(Status(absl::StatusCode::kCancelled, "cancelled"));
+  StatusOr<int*> thing(absl::Status(absl::StatusCode::kCancelled, "cancelled"));
   EXPECT_DEATH(thing.value(), "");
 }
 
 TEST(StatusOrDeathTest, TestPointerValueNotOkConst) {
-  const StatusOr<int*> thing(Status(absl::StatusCode::kCancelled, "cancelled"));
+  const StatusOr<int*> thing(absl::Status(absl::StatusCode::kCancelled, "cancelled"));
   EXPECT_DEATH(thing.value(), "");
 }
 
 // Benchmarks were removed as we not intend to change forked code.
 
-} // namespace
-} // namespace absl
+}  // namespace
+}  // namespace cloudevents_absl

--- a/v1/event_format/format.h
+++ b/v1/event_format/format.h
@@ -4,10 +4,8 @@
 namespace cloudevents {
 namespace format {
 
-/*
- * This enum class is used in this SDK to represent
- * an Event Format as defined by the spec.
- */
+// This enum class is used in this SDK to represent
+// an Event Format as defined by the spec.
 enum class Format {kJson};
 
 }  // namespace format

--- a/v1/event_format/formatter.h
+++ b/v1/event_format/formatter.h
@@ -8,19 +8,20 @@
 namespace cloudevents {
 namespace format {
 
-/*
- * Abstract Class that will have a concrete implementation for each supported EventFormat.
- * Formatters will handle marshalling between CloudEvents and 
- * StructuredCloudEvents (serializations based on EventFormats)
- */
+// Abstract Class that will have a concrete implementation
+// for each supported EventFormat.
+// Formatters will handle marshalling between CloudEvents and
+// StructuredCloudEvents (serializations based on EventFormats)
 class Formatter {
  public:
   // Marshal a CloudEvent into a StructuredCloudEvent
-  virtual absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> Serialize(
+  virtual cloudevents_absl::StatusOr<
+    std::unique_ptr<StructuredCloudEvent>> Serialize(
     const io::cloudevents::v1::CloudEvent& cloud_event) = 0;
 
   // Marshal a StructuredCloudEvent into a CloudEvent
-  virtual absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
+  virtual cloudevents_absl::StatusOr<
+    io::cloudevents::v1::CloudEvent> Deserialize(
     const StructuredCloudEvent& structured_cloud_event) = 0;
 
   // Pure virtual destructor as any class with virtual functions

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -27,13 +27,14 @@ constexpr char kErrProtobufAny[] = "protobuf::Any not supported yet.";
 constexpr char kErrNotJson[] = "The given serialized data should not be handled by JsonFormatter because it is not JSON-formatted.";
 constexpr char kErrTwoPayloads[] = "The given serialized data is invalid because it contains two data payloads.";
 
-absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> JsonFormatter::Serialize(
+cloudevents_absl::StatusOr<
+    std::unique_ptr<StructuredCloudEvent>> JsonFormatter::Serialize(
     const CloudEvent& cloud_event) {
   if (auto is_valid = CloudEventsUtil::IsValid(cloud_event); !is_valid.ok()) {
     return is_valid;
   }
 
-  absl::StatusOr<CeAttrMap> attrs = CloudEventsUtil::GetMetadata(
+  cloudevents_absl::StatusOr<CeAttrMap> attrs = CloudEventsUtil::GetMetadata(
     cloud_event);
   if (!attrs.ok()) {
     return attrs.status();
@@ -41,7 +42,8 @@ absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> JsonFormatter::Serialize(
 
   Json::Value root;
   for (auto const& attr : *attrs) {
-    absl::StatusOr<Json::Value> json_printed = PrintToJson(attr.second);
+    cloudevents_absl::StatusOr<Json::Value> json_printed =
+      PrintToJson(attr.second);
     if (!json_printed.ok()) {
       return json_printed.status();
     }
@@ -71,7 +73,7 @@ absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> JsonFormatter::Serialize(
   return structured_ce;
 }
 
-absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
+cloudevents_absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
     const StructuredCloudEvent& structured_ce) {
   // Validate that this is the right format to be handled by this object
   if (structured_ce.format != Format::kJson) {
@@ -119,7 +121,7 @@ absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
   return cloud_event;
 }
 
-absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(
+cloudevents_absl::StatusOr<Json::Value> JsonFormatter::PrintToJson(
     const CloudEvent_CloudEventAttribute& attr){
   switch (attr.attr_oneof_case()) {
     case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:

--- a/v1/event_format/json_formatter.h
+++ b/v1/event_format/json_formatter.h
@@ -11,24 +11,22 @@
 namespace cloudevents {
 namespace format {
 
-/*
- * Implementation of Formatter for JSON EventFormat
- */
+// Implementation of Formatter for JSON EventFormat
 class JsonFormatter: public Formatter {
  public:
   // Create Json-formatted serialization from CloudEvent
-  absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> Serialize(
+  cloudevents_absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> Serialize(
     const io::cloudevents::v1::CloudEvent& cloud_event) override;
 
   // Create CloudEvent from Json-formatted serialization
-  absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
+  cloudevents_absl::StatusOr<io::cloudevents::v1::CloudEvent> Deserialize(
     const StructuredCloudEvent& structured_ce) override;
 
  private:
   // Convert from CE to JSON Type System according to
   // Relies on the overloaded constructor for Json::Value in jsoncpp
   // https://github.com/cloudevents/spec/blob/master/json-format.md#22-type-system-mapping
-  absl::StatusOr<Json::Value> PrintToJson(
+  cloudevents_absl::StatusOr<Json::Value> PrintToJson(
     const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
 };
 

--- a/v1/event_format/json_formatter_test.cc
+++ b/v1/event_format/json_formatter_test.cc
@@ -14,7 +14,7 @@ TEST(Serialize, NoData) {
   cloud_event.set_type("test");
   std::string expected_ser = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
   JsonFormatter json_formatter;
-  absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
+  cloudevents_absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
 
   serialize = json_formatter.Serialize(cloud_event);
 
@@ -33,7 +33,7 @@ TEST(Serialize, BinaryData) {
   cloud_event.set_binary_data("0110");
   std::string expected_ser = "{\n\t\"data_base64\" : \"0110\",\n\t\"id\" : \"4545\",\n\t\"source\" : \"/bonk+bonk\",\n\t\"spec_version\" : \"3.xxxxx\",\n\t\"type\" : \"new\"\n}";
   JsonFormatter json_formatter;
-  absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
+  cloudevents_absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
 
   serialize = json_formatter.Serialize(cloud_event);
 
@@ -51,7 +51,7 @@ TEST(Serialize, TextData) {
   cloud_event.set_text_data("this is text");
   std::string expected_ser = "{\n\t\"data\" : \"this is text\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"4.xxxxx\",\n\t\"type\" : \"not_a_type\"\n}";
   JsonFormatter json_formatter;
-  absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
+  cloudevents_absl::StatusOr<std::unique_ptr<StructuredCloudEvent>> serialize;
 
   serialize = json_formatter.Serialize(cloud_event);
 
@@ -65,7 +65,7 @@ TEST(Deserialize, NoData) {
   structured_ce.format = Format::kJson;
   structured_ce.serialized_data = "{\n\t\"id\" : \"1\",\n\t\"source\" : \"/test\",\n\t\"spec_version\" : \"1.0\",\n\t\"type\" : \"test\"\n}";
   JsonFormatter json_formatter;
-  absl::StatusOr<CloudEvent> deserialize;
+  cloudevents_absl::StatusOr<CloudEvent> deserialize;
 
   deserialize = json_formatter.Deserialize(structured_ce);
 
@@ -81,7 +81,7 @@ TEST(Deserialize, BinaryData) {
   structured_ce.format = Format::kJson;
   structured_ce.serialized_data = "{\n\t\"data_base64\" : \"binary_data_wow\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"3.xxxxx\",\n\t\"type\" : \"not_a_type\"\n}";
   JsonFormatter json_formatter;
-  absl::StatusOr<CloudEvent> deserialize;
+  cloudevents_absl::StatusOr<CloudEvent> deserialize;
 
   deserialize = json_formatter.Deserialize(structured_ce);
 
@@ -98,7 +98,7 @@ TEST(Deserialize, TextData) {
   structured_ce.format = Format::kJson;
   structured_ce.serialized_data = "{\n\t\"data\" : \"this is text\",\n\t\"id\" : \"9999999\",\n\t\"source\" : \"/test/qwertyuiop\",\n\t\"spec_version\" : \"4\",\n\t\"type\" : \"not_a_type\"\n}";
   JsonFormatter json_formatter;
-  absl::StatusOr<CloudEvent> deserialize;
+  cloudevents_absl::StatusOr<CloudEvent> deserialize;
 
   deserialize = json_formatter.Deserialize(structured_ce);
 

--- a/v1/event_format/structured_cloud_event.h
+++ b/v1/event_format/structured_cloud_event.h
@@ -6,10 +6,8 @@
 namespace cloudevents {
 namespace format {
 
-/*
- * An internal representation of a CloudEvent that has been formatted/ serialized
- * according to an EventFormat spec.
- */
+// An internal representation of a CloudEvent that has been formatted/ serialized
+// according to an EventFormat spec.
 struct StructuredCloudEvent {
   // The EventFormat spec used to create this serialization
   Format format;

--- a/v1/util/cloud_events_util.cc
+++ b/v1/util/cloud_events_util.cc
@@ -25,7 +25,7 @@ absl::Status CloudEventsUtil::IsValid(const CloudEvent& cloud_event) {
   return absl::OkStatus();
 }
 
-absl::StatusOr<
+cloudevents_absl::StatusOr<
     absl::flat_hash_map<std::string, CloudEvent_CloudEventAttribute>>
     CloudEventsUtil::GetMetadata(const CloudEvent& cloud_event) {
   if (auto is_valid = CloudEventsUtil::IsValid(cloud_event); !is_valid.ok()) {
@@ -47,7 +47,7 @@ absl::StatusOr<
 }
 
 absl::Status CloudEventsUtil::SetMetadata(const std::string& key,
-    const std::string& val, CloudEvent& cloud_event){
+    const std::string& val, CloudEvent& cloud_event) {
   // TODO (#39): Recognize URI and URI Reference types
   if (key == "id") {
     cloud_event.set_id(val);
@@ -74,7 +74,7 @@ absl::Status CloudEventsUtil::SetMetadata(const std::string& key,
   return absl::OkStatus();
 }
 
-absl::StatusOr<std::string> CloudEventsUtil::ToString(
+cloudevents_absl::StatusOr<std::string> CloudEventsUtil::ToString(
     const CloudEvent_CloudEventAttribute& attr){
   switch (attr.attr_oneof_case()) {
     case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBoolean:
@@ -86,7 +86,7 @@ absl::StatusOr<std::string> CloudEventsUtil::ToString(
     case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeString:
       return attr.ce_string();
     case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeBinary:
-      return base64::base64_encode(attr.ce_binary());
+      return cloudevents_base64::base64_encode(attr.ce_binary());
     case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeUri:
       return attr.ce_uri();
     case CloudEvent_CloudEventAttribute::AttrOneofCase::kCeUriReference:

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -16,7 +16,7 @@ class CloudEventsUtil {
     const io::cloudevents::v1::CloudEvent& cloud_event);
 
   // get metadata from CloudEvent in a single map
-  static absl::StatusOr<absl::flat_hash_map<
+  static cloudevents_absl::StatusOr<absl::flat_hash_map<
     std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
     GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
 
@@ -29,7 +29,7 @@ class CloudEventsUtil {
 
   // convert CloudEvent attributes to canonical string representaiton
   // https://github.com/cloudevents/spec/blob/master/spec.md#type-system
-  static absl::StatusOr<std::string> ToString(
+  static cloudevents_absl::StatusOr<std::string> ToString(
     const io::cloudevents::v1::CloudEvent_CloudEventAttribute& attr);
 
   // convert std::string to ce-string.

--- a/v1/util/cloud_events_util_test.cc
+++ b/v1/util/cloud_events_util_test.cc
@@ -83,8 +83,8 @@ TEST(CloudEventsUtilTest, GetMetadata_NoOptional) {
   cloud_event.set_spec_version("1.0");
   cloud_event.set_type("test");
 
-  absl::StatusOr<CeAttrMap> get_metadata = CloudEventsUtil::GetMetadata(
-    cloud_event);
+  cloudevents_absl::StatusOr<CeAttrMap> get_metadata =
+    CloudEventsUtil::GetMetadata(cloud_event);
 
   ASSERT_TRUE(get_metadata.ok());
   ASSERT_EQ((*get_metadata)["id"].ce_string(), "1");
@@ -104,8 +104,8 @@ TEST(CloudEventsUtilTest, GetMetadata_OneOptional) {
   attr.set_ce_string("test_val");
   (*cloud_event.mutable_attributes())["test_key"] = attr;
 
-  absl::StatusOr<CeAttrMap> get_metadata = CloudEventsUtil::GetMetadata(
-    cloud_event);
+  cloudevents_absl::StatusOr<CeAttrMap> get_metadata =
+    CloudEventsUtil::GetMetadata(cloud_event);
 
   ASSERT_TRUE(get_metadata.ok());
   ASSERT_EQ((*get_metadata)["id"].ce_string(), "1");
@@ -127,8 +127,8 @@ TEST(CloudEventsUtilTest, GetMetadata_TwoOptional) {
   attr.set_ce_string("test_val2");
   (*cloud_event.mutable_attributes())["test_key2"] = attr;
 
-  absl::StatusOr<CeAttrMap> get_metadata = CloudEventsUtil::GetMetadata(
-    cloud_event);
+  cloudevents_absl::StatusOr<CeAttrMap> get_metadata =
+    CloudEventsUtil::GetMetadata(cloud_event);
 
   ASSERT_TRUE(get_metadata.ok());
   ASSERT_EQ((*get_metadata)["id"].ce_string(), "1");
@@ -208,8 +208,8 @@ TEST(CloudEventsUtilTest, ToString_BoolFalse) {
   CloudEvent_CloudEventAttribute attr;
   attr.set_ce_boolean(false);
 
-  absl::StatusOr<std::string> stringify_ce_type = CloudEventsUtil::ToString(
-    attr);
+  cloudevents_absl::StatusOr<std::string> stringify_ce_type =
+    CloudEventsUtil::ToString(attr);
 
   ASSERT_TRUE(stringify_ce_type.ok());
   ASSERT_EQ(*stringify_ce_type, "false");
@@ -219,8 +219,8 @@ TEST(CloudEventsUtilTest, ToString_BoolTrue) {
   CloudEvent_CloudEventAttribute attr;
   attr.set_ce_boolean(true);
 
-  absl::StatusOr<std::string> stringify_ce_type = CloudEventsUtil::ToString(
-    attr);
+  cloudevents_absl::StatusOr<std::string> stringify_ce_type =
+    CloudEventsUtil::ToString(attr);
 
   ASSERT_TRUE(stringify_ce_type.ok());
   ASSERT_EQ(*stringify_ce_type, "true");
@@ -230,8 +230,8 @@ TEST(CloudEventsUtilTest, ToString_Integer) {
   CloudEvent_CloudEventAttribute attr;
   attr.set_ce_integer(88);
 
-  absl::StatusOr<std::string> stringify_ce_type = CloudEventsUtil::ToString(
-    attr);
+  cloudevents_absl::StatusOr<std::string> stringify_ce_type =
+    CloudEventsUtil::ToString(attr);
 
   ASSERT_TRUE(stringify_ce_type.ok());
   ASSERT_EQ(*stringify_ce_type, "88");
@@ -241,8 +241,8 @@ TEST(CloudEventsUtilTest, ToString_String) {
   CloudEvent_CloudEventAttribute attr;
   attr.set_ce_string("test");
 
-  absl::StatusOr<std::string> stringify_ce_type = CloudEventsUtil::ToString(
-    attr);
+  cloudevents_absl::StatusOr<std::string> stringify_ce_type =
+    CloudEventsUtil::ToString(attr);
 
   ASSERT_TRUE(stringify_ce_type.ok());
   ASSERT_EQ(*stringify_ce_type, "test");
@@ -252,8 +252,8 @@ TEST(CloudEventsUtilTest, ToString_URI) {
   CloudEvent_CloudEventAttribute attr;
   attr.set_ce_uri("https://google.com");
 
-  absl::StatusOr<std::string> stringify_ce_type = CloudEventsUtil::ToString(
-    attr);
+  cloudevents_absl::StatusOr<std::string> stringify_ce_type =
+    CloudEventsUtil::ToString(attr);
 
   ASSERT_TRUE(stringify_ce_type.ok());
   ASSERT_EQ(*stringify_ce_type, "https://google.com");
@@ -263,8 +263,8 @@ TEST(CloudEventsUtilTest, ToString_URIRef) {
   CloudEvent_CloudEventAttribute attr;
   attr.set_ce_uri_reference("https://www.google.com/#fragment");
 
-  absl::StatusOr<std::string> stringify_ce_type = CloudEventsUtil::ToString(
-    attr);
+  cloudevents_absl::StatusOr<std::string> stringify_ce_type =
+    CloudEventsUtil::ToString(attr);
 
   ASSERT_TRUE(stringify_ce_type.ok());
   ASSERT_EQ(*stringify_ce_type, "https://www.google.com/#fragment");
@@ -276,8 +276,8 @@ TEST(CloudEventsUtilTest, ToString_Timestamp) {
   CloudEvent_CloudEventAttribute attr;
   attr.mutable_ce_timestamp()-> MergeFrom(timestamp);
 
-  absl::StatusOr<std::string> stringify_ce_type = CloudEventsUtil::ToString(
-    attr);
+  cloudevents_absl::StatusOr<std::string> stringify_ce_type =
+    CloudEventsUtil::ToString(attr);
 
   ASSERT_EQ(*stringify_ce_type, timestamp_str);
 }
@@ -285,8 +285,8 @@ TEST(CloudEventsUtilTest, ToString_Timestamp) {
 TEST(CloudEventsUtilTest, ToString_NotSet) {
   CloudEvent_CloudEventAttribute attr;
 
-  absl::StatusOr<std::string> stringify_ce_type = CloudEventsUtil::ToString(
-    attr);
+  cloudevents_absl::StatusOr<std::string> stringify_ce_type =
+    CloudEventsUtil::ToString(attr);
 
   ASSERT_TRUE(absl::IsInvalidArgument(stringify_ce_type.status()));
 }


### PR DESCRIPTION
- add `cloudevents_` prefix to all third party namespaces*
- update existing code to use updated namespaces

*this is done in order to prevent collisions with other libraries using the same third party source code

- [x] Tests pass