### PR TITLE
[Stage 0] Cleanup todos

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,14 +54,14 @@ git_repository(
 # Used to get PubSub message proto
 
 http_archive(
-    name = "googleapis",
+    name = "com_google_googleapis",
     urls = ["https://github.com/googleapis/googleapis/archive/master.zip"],
     # commented out SHA as it is flaky
     #sha256 = "58d0c3e2bf38d25c4a0be7939166ca263bfc4fe58d3cfc83d05576cb04b97cc7",
     strip_prefix = "googleapis-master",
 )
 
-load("@googleapis//:repository_rules.bzl", "switched_rules_by_language")
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 
 switched_rules_by_language(
     name = "com_google_googleapis_imports",

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -20,5 +20,5 @@ proto_library(
 cc_proto_library(
   name = "pubsub_cc_proto",
   visibility = ["//visibility:public"],
-  deps = ["@googleapis//google/pubsub/v1:pubsub_proto"],
+  deps = ["@com_google_googleapis//google/pubsub/v1:pubsub_proto"],
 )

--- a/samples/create_event.cc
+++ b/samples/create_event.cc
@@ -38,8 +38,6 @@ absl::Status WriteToFile(std::string file_path, io::cloudevents::v1::CloudEvent*
 }
 
 absl::Status PopulateEvent(io::cloudevents::v1::CloudEvent* event){
-    // TODO (#7): Abstract this out to a Buider with validation.
-
     GetUserInput("Enter id", *event -> mutable_id());
     GetUserInput("Enter source", *event -> mutable_source());
     GetUserInput("Enter spec_version", *event -> mutable_spec_version());
@@ -49,7 +47,6 @@ absl::Status PopulateEvent(io::cloudevents::v1::CloudEvent* event){
     GetUserInput("Would you like to enter data (y/n)", has_data);
     if (has_data=="y") {
         std::string data_type;
-        // TODO (#6): Support Any data
         GetUserInput("Enter data type (bytes/ string)", data_type);
         const static std::unordered_map<std::string,int> data_type_to_case{
             {"bytes",1},
@@ -92,7 +89,6 @@ int main(int argc, char* argv[]) {
     }
     
     // create an event
-    // TODO (#8): handle optional and extension attrs
     program_status = PopulateEvent(&event);
     if (!program_status.ok()) {
         OutputToInterface(program_status.ToString(), -1);

--- a/third_party/base64/base64.h
+++ b/third_party/base64/base64.h
@@ -2,6 +2,7 @@
 //  base64 encoding and decoding with C++.
 //  Version: 2.rc.04 (release candidate)
 //
+// TODO (#51): Switch to MIT base64 lib for faster performance
 
 #ifndef BASE64_H_C0CE2A47_D10E_42C9_A27C_C883944E704A
 #define BASE64_H_C0CE2A47_D10E_42C9_A27C_C883944E704A

--- a/third_party/statusor/BUILD
+++ b/third_party/statusor/BUILD
@@ -13,7 +13,6 @@ cc_library(
     deps = ["@com_google_absl//absl/status"]
 )
 
-#TODO (Michelle): fix tests
 cc_test(
    name = "statusor_test",
    srcs = ["statusor_test.cc"],

--- a/third_party/statusor/statusor.h
+++ b/third_party/statusor/statusor.h
@@ -78,6 +78,7 @@
 #include "absl/base/attributes.h"
 #include "absl/base/macros.h"
 
+// TODO (#61): Switch to official absl::StatusOr release when available
 namespace cloudevents_absl {
 
 // Returned StatusOr objects may not be ignored.

--- a/v1/event_format/BUILD
+++ b/v1/event_format/BUILD
@@ -1,11 +1,30 @@
 cc_library(
+    name = "format_lib",
+    hdrs = [
+        "format.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "formatter_lib",
+    hdrs = [
+        "formatter.h",
+        "structured_cloud_event.h",
+    ],
+    deps = [
+        "//proto:cloud_event_cc_proto",
+        "//third_party/statusor:statusor_lib",
+        ":format_lib",
+    ],
+)
+
+
+cc_library(
     name = "json_formatter_lib",
     srcs = ["json_formatter.cc"],
     hdrs = [
         "json_formatter.h",
-        "formatter.h",
-        "structured_cloud_event.h",
-        "format.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -13,6 +32,7 @@ cc_library(
         "//proto:cloud_event_cc_proto",
         "//third_party/statusor:statusor_lib",
         "//v1/util:cloud_events_util_lib",
+        ":formatter_lib",
     ],
 )
 

--- a/v1/event_format/json_formatter.cc
+++ b/v1/event_format/json_formatter.cc
@@ -98,7 +98,6 @@ cloudevents_absl::StatusOr<CloudEvent> JsonFormatter::Deserialize(
 
   CloudEvent cloud_event;
 
-  // TODO (#39): Should we try to infer CE Type from serialized_data?
   for (auto const& member : root.getMemberNames()) {
     if (auto set_metadata = CloudEventsUtil::SetMetadata(member,
       root[member].asString(), cloud_event); !set_metadata.ok()) {

--- a/v1/util/binder_util.cc
+++ b/v1/util/binder_util.cc
@@ -6,10 +6,11 @@ namespace binder_util {
 constexpr char kMetadataPrefix[] = "ce-";
 constexpr char kContentTypePrefix[] = "application/cloudevents+";
 
-// length of prefix constants are made constexpr to avoid
-// multiple calls to strlen()
-constexpr size_t kMetadataPrefixLen = strlen(kMetadataPrefix);
-constexpr size_t kContentTypePrefixLen = strlen(kContentTypePrefix);
+// Length of prefix constants are made constexpr to avoid
+// multiple calls to sizeof().
+// Does not count the NULL character.
+constexpr size_t kMetadataPrefixLen = sizeof(kMetadataPrefix) - 1;
+constexpr size_t kContentTypePrefixLen = sizeof(kContentTypePrefix) - 1;
 
 constexpr char kErrNoPrefix[] = "Prefix is not present in the given value.";
 

--- a/v1/util/cloud_events_util.h
+++ b/v1/util/cloud_events_util.h
@@ -20,8 +20,6 @@ class CloudEventsUtil {
     std::string, io::cloudevents::v1::CloudEvent_CloudEventAttribute>>
     GetMetadata(const io::cloudevents::v1::CloudEvent& cloud_event);
 
-  // TODO (#44): Overload SetMetadata to accept a map of attributes
-
   // set metadata without dealing with CloudEvent proto structure
   static absl::Status SetMetadata(const std::string& key,
     const std::string& val,


### PR DESCRIPTION
*These PRs are independent from all the other PRs. The relative order of merging does not matter.*

- handles dataschema (URI CE Type) in SetMetadata
- make separate bazel targets for format and formatter
- remove outdated todos
- add todos for future improvement

- [x] Tests pass
- [x] Appropriate documentation in comments
